### PR TITLE
Expand homebrew post-install message

### DIFF
--- a/homebrew/chruby.rb
+++ b/homebrew/chruby.rb
@@ -17,10 +17,15 @@ class Chruby < Formula
       . #{prefix}/share/chruby/chruby.sh
 
       RUBIES=(
-        /usr/local/ruby-1.9.3
-        /opt/jruby-1.7.0
-        /Users/username/.rbenv/versions/2.0.0-preview1
+        # Examples:
+        #
+        # /usr/local/ruby-1.9.3
+        # /opt/jruby-1.7.0
+        # #{ENV['HOME']}/.rbenv/versions/2.0.0-preview1
+        # #{ENV['HOME']}/.rvm/gems/rbx-2.0.0-rc1
       )
+
+    $RUBIES should contain a list of existing Ruby installation paths.
 
     For system-wide installation, add the above text to /etc/profile.
 


### PR DESCRIPTION
Just a few minor changes to the homebrew post-installation message. I have a sneaking suspicion that people regularly copy-and-paste this output without looking at it, so I commented out the paths.

I also added path examples for Rubies installed by rbenv and rvm. I can't confirm that chruby plays well w/ rvm, but it seems to work fine w/ rbenv/ruby-build binaries.
