### PR TITLE
Fix missing bin/ruby in instaling jruby 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ or via [ruby-build].
 
         wget http://jruby.org.s3.amazonaws.com/downloads/1.7.0/jruby-bin-1.7.0.tar.gz
         tar -xzvf jruby-bin-1.7.0.tar.gz -C /usr/local
+        ln -s /usr/local/jruby-1.7.0/bin/jruby /usr/local/jruby-1.7.0/bin/ruby
 
 ### Rubinius
 


### PR DESCRIPTION
jruby does not provide bin/ruby by default, added instruction to create symlink that adds it
