### PR TITLE
add mruby installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ or via [ruby-build].
         ./configure --prefix=/usr/local/rubinius-2.0.0-rc1
         rake
         rake install
+        
+### MRuby
+
+* Requirements: [Bison]
+
+        git clone https://github.com/mruby/mruby.git /usr/local/mruby-dev
+        cd /usr/local/mruby-dev
+        make
+
+(MRuby commands are mirb (irb), mrbc (compile to C), and mruby (ruby). MRuby does not support RubyGems.)
 
 ## Configuration
 


### PR DESCRIPTION
I added simple instructions to get mruby installed with chruby. Caveats being many... preliminary mruby-dev release, RubyGem paths are meaningless for mruby, and should mirb and mruby be aliased to irb and ruby?
