### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ or via [ruby-build].
         wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p327.tar.gz
         tar -xzvf ruby-1.9.3-p327.tar.gz
         cd ruby-1.9.3-p327
-        ./configure --prefix=/usr/local/ruby-1.9.3-p237
+        ./configure --prefix=/usr/local/ruby-1.9.3-p327
         make
         make install
 


### PR DESCRIPTION
There was a typing error in the README instructions.  Under MRI ruby installation instructions, the ruby patch number should have been 327 whereas it is 237.
