### PR TITLE
Homebrew instructions for chruby formula (brew install chruby).

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ with:
 
 chruby can also be installed with [homebrew]:
 
-    brew install https://raw.github.com/postmodern/chruby/master/homebrew/chruby.rb
+    brew install chruby
 
 ### Rubies
 


### PR DESCRIPTION
Homebrew pulled chruby formula, so `brew install chruby` works.
