### PR TITLE
Updates JRuby to 1.7.1

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,7 +6,7 @@ set -e
 # Constants
 #
 MRI_VERSION="1.9.3-p362"
-JRUBY_VERSION="1.7.0"
+JRUBY_VERSION="1.7.1"
 RUBINIUS_VERSION="2.0.0-rc1"
 
 [[ -z "$PREFIX"      ]] && export PREFIX="/usr/local"


### PR DESCRIPTION
This updates the setup script to install the recently released JRuby 1.7.1 instead of 1.7.0. I know its not much, but its something :)
