### PR TITLE
Unset RUBY_VERSION_FILE when loading auto.sh

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -35,3 +35,5 @@ else
 		PROMPT_COMMAND="chruby_auto"
 	fi
 fi
+
+unset RUBY_VERSION_FILE

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -13,6 +13,7 @@ setUp()
 
 test_chruby_auto_loaded_twice()
 {
+	RUBY_VERSION_FILE="dirty"
 	. ./share/chruby/auto.sh
 
 	if [[ -n "$ZSH_VERSION" ]]; then
@@ -24,6 +25,8 @@ test_chruby_auto_loaded_twice()
 			        "$PROMPT_COMMAND" \
 		                "chruby_auto; chruby_auto"
 	fi
+
+	assertNull "RUBY_VERSION_FILE was not unset" "$RUBY_VERSION_FILE"
 }
 
 test_chruby_auto_enter_project_dir()


### PR DESCRIPTION
Ensure that chruby will be called or reseted after auto.sh is loaded.
This fixes a problem when for example a new tmux window is opened and environment variables (including RUBY_*) reserved, but PATH is reset in .zshrc/.bashrc. The root cause is thus same than in #46.
