### PR TITLE
Use bash in scripts and tests

### DIFF
--- a/scripts/bug_report.sh
+++ b/scripts/bug_report.sh
@@ -1,5 +1,3 @@
-#!/bin/sh -il
-
 function print_section()
 {
 	echo

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . ./share/chruby/auto.sh
 . ./test/helper.sh
 

--- a/test/chruby_exec_test.sh
+++ b/test/chruby_exec_test.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . ./test/helper.sh
 
 test_chruby_exec_no_arguments()

--- a/test/chruby_reset_test.sh
+++ b/test/chruby_reset_test.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . ./test/helper.sh
 
 setUp()

--- a/test/chruby_test.sh
+++ b/test/chruby_test.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . ./test/helper.sh
 
 tearDown()

--- a/test/chruby_use_test.sh
+++ b/test/chruby_use_test.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 . ./test/helper.sh
 
 setUp()

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 [[ -z "$SHUNIT2"     ]] && SHUNIT2=/usr/share/shunit2/shunit2
 [[ -n "$ZSH_VERSION" ]] && setopt shwordsplit
 

--- a/test/runner
+++ b/test/runner
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 log() {
 	if [[ -t 1 ]]; then


### PR DESCRIPTION
At least `[[ ]]` and arrays are not Posix shell compatible, so use bash by default.

Test files are normally run via runner using bash and zsh, but the runner itself uses `[[ ]]` which complains with dash.
