### PR TITLE
Fix test runner's exit code if any test fail

### DIFF
--- a/test/runner
+++ b/test/runner
@@ -10,8 +10,11 @@ log() {
 
 log "Running tests under $SHELL ..."
 
+error=0
 for test in $(dirname $0)/*_test.sh; do
 	log "Running $test ..."
-	$SHELL $test
+	$SHELL $test || error=1
 	echo
 done
+
+exit $error


### PR DESCRIPTION
The test runner returns now always with 0 exit code making it hard to notice possible errors.
