### PR TITLE
Fix auto-switching tests

### DIFF
--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -34,7 +34,7 @@ test_chruby_auto_enter_project_dir()
 	cd "$PROJECT_DIR" && chruby_auto
 
 	assertEquals "did not switch Ruby when entering a versioned directory" \
-		     "$TEST_RUBY" "$RUBY"
+		     "$TEST_RUBY_ROOT" "$RUBY_ROOT"
 }
 
 test_chruby_auto_enter_subdir_directly()
@@ -42,7 +42,7 @@ test_chruby_auto_enter_subdir_directly()
 	cd "$PROJECT_DIR/sub_dir" && chruby_auto
 
 	assertEquals "did not switch Ruby when directly entering a sub-directory of a versioned directory" \
-		     "$TEST_RUBY" "$RUBY"
+		     "$TEST_RUBY_ROOT" "$RUBY_ROOT"
 }
 
 test_chruby_auto_enter_subdir()
@@ -51,7 +51,7 @@ test_chruby_auto_enter_subdir()
 	cd sub_dir        && chruby_auto
 
 	assertEquals "did not keep the current Ruby when entering a sub-dir" \
-		     "$TEST_RUBY" "$RUBY"
+		     "$TEST_RUBY_ROOT" "$RUBY_ROOT"
 }
 
 test_chruby_auto_enter_subdir_with_ruby_version()
@@ -60,7 +60,7 @@ test_chruby_auto_enter_subdir_with_ruby_version()
 	cd sub_versioned  && chruby_auto
 
 	assertNull "did not switch the Ruby when leaving a sub-versioned directory" \
-		   "$RUBY"
+		   "$RUBY_ROOT"
 }
 
 test_chruby_auto_overriding_ruby_version()
@@ -68,7 +68,7 @@ test_chruby_auto_overriding_ruby_version()
 	cd "$PROJECT_DIR" && chruby_auto
 	chruby system     && chruby_auto
 
-	assertNull "did not override the Ruby set in .ruby-version" "$RUBY"
+	assertNull "did not override the Ruby set in .ruby-version" "$RUBY_ROOT"
 }
 
 test_chruby_auto_leave_project_dir()
@@ -78,7 +78,7 @@ test_chruby_auto_leave_project_dir()
 	cd ../../..       && chruby_auto
 
 	assertNull "did not reset the Ruby when leaving a versioned directory" \
-		   "$RUBY"
+		   "$RUBY_ROOT"
 }
 
 test_chruby_auto_invalid_ruby_version()
@@ -87,7 +87,7 @@ test_chruby_auto_invalid_ruby_version()
 	cd bad            && chruby_auto 2>/dev/null
 
 	assertEquals "did not keep the current Ruby when loading an unknown version" \
-		     "$TEST_RUBY" "$RUBY"
+		     "$TEST_RUBY_ROOT" "$RUBY_ROOT"
 }
 
 SHUNIT_PARENT=$0 . $SHUNIT2


### PR DESCRIPTION
The correct variable is RUBY_ROOT, not RUBY. It seemed to be renamed during
the development of auto-switching functionality.
