### PR TITLE
Setting PROMPT_COMMAND when blank in auto.sh

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -29,9 +29,13 @@ if [[ -n "$ZSH_VERSION" ]]; then
 		precmd_functions+=("chruby_auto")
 	fi
 elif [[ -n "$BASH_VERSION" ]]; then
-	if [[ ! "$PROMPT_COMMAND" == *chruby_auto* ]]; then
-		PROMPT_COMMAND="${PROMPT_COMMAND%% }"
-		PROMPT_COMMAND="${PROMPT_COMMAND%%;}"
-		PROMPT_COMMAND="$PROMPT_COMMAND; chruby_auto"
+	if [[ -n "$PROMPT_COMMAND" ]]; then
+		if [[ ! "$PROMPT_COMMAND" == *chruby_auto* ]]; then
+			PROMPT_COMMAND="${PROMPT_COMMAND%% }"
+			PROMPT_COMMAND="${PROMPT_COMMAND%%;}"
+			PROMPT_COMMAND="$PROMPT_COMMAND; chruby_auto"
+		fi
+	else
+		PROMPT_COMMAND="chruby_auto"
 	fi
 fi

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -9,6 +9,18 @@ setUp()
 	unset RUBY_VERSION_FILE
 }
 
+test_chruby_auto_setting_blank_PROMPT_COMMAND()
+{
+	if [[ -n "$BASH_VERSION" ]]; then
+		PROMPT_COMMAND=""
+		. ./share/chruby/auto.sh
+
+		assertEquals "has syntax error" \
+			     "chruby_auto" \
+			     "$PROMPT_COMMAND"
+	fi
+}
+
 test_chruby_auto_setting_PROMPT_COMMAND_with_semicolon()
 {
 	if [[ -n "$BASH_VERSION" ]]; then


### PR DESCRIPTION
Issue was mentioned here: https://github.com/postmodern/chruby/issues/99#issuecomment-13823660

When PROMPT_COMMAND is blank, appending will cause syntax error.

```
-bash: PROMPT_COMMAND: line 4: syntax error near unexpected token `;'
-bash: PROMPT_COMMAND: line 4: `; chruby_auto'
```
