### PR TITLE
~/.ruby-version sets default ruby only for home directory tree

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -22,6 +22,9 @@ function chruby_auto() {
 		dir="${dir%/*}"
 	done
 
+	chruby_auto_use "$HOME"
+	[[ $? == 2 ]] || return $?
+
 	if [[ -n "$RUBY_VERSION_FILE" ]]; then
 		chruby_reset
 		unset RUBY_VERSION_FILE

--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -5,12 +5,10 @@ function chruby_auto_use() {
 
 	if   [[ "$version_file" == "$RUBY_VERSION_FILE" ]]; then return
 	elif [[ -f "$version_file" ]]; then
-		chruby $(cat "$version_file") || return 1
-
 		export RUBY_VERSION_FILE="$version_file"
-		return
+		chruby $(cat "$version_file") || return 1
+	else return 2
 	fi
-	return 2
 }
 
 function chruby_auto() {

--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -1,20 +1,24 @@
 unset RUBY_VERSION_FILE
 
+function chruby_auto_use() {
+	local version_file="$1/.ruby-version"
+
+	if   [[ "$version_file" == "$RUBY_VERSION_FILE" ]]; then return
+	elif [[ -f "$version_file" ]]; then
+		chruby $(cat "$version_file") || return 1
+
+		export RUBY_VERSION_FILE="$version_file"
+		return
+	fi
+	return 2
+}
+
 function chruby_auto() {
 	local dir="$PWD"
-	local version_file
 
 	until [[ -z "$dir" ]]; do
-		version_file="$dir/.ruby-version"
-
-		if   [[ "$version_file" == "$RUBY_VERSION_FILE" ]]; then return
-		elif [[ -f "$version_file" ]]; then
-			chruby $(cat "$version_file") || return 1
-
-			export RUBY_VERSION_FILE="$version_file"
-			return
-		fi
-
+		chruby_auto_use "$dir"
+		[[ $? == 2 ]] || return $?
 		dir="${dir%/*}"
 	done
 

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -126,4 +126,13 @@ test_chruby_auto_invalid_ruby_version()
 		     "$TEST_RUBY_ROOT" "$RUBY_ROOT"
 }
 
+test_chruby_default()
+{
+	cd "$PROJECT_DIR/sub_dir" && chruby_auto
+	cd ../..                  && HOME="$PROJECT_DIR" chruby_auto
+
+	assertEquals "did not use ~/.ruby-version when leaving a versioned directory" \
+		     "$TEST_RUBY_ROOT" "$RUBY_ROOT"
+}
+
 SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -95,7 +95,7 @@ test_chruby_auto_enter_subdir_with_ruby_version()
 	cd "$PROJECT_DIR" && chruby_auto
 	cd sub_versioned  && chruby_auto
 
-	assertNull "did not switch the Ruby when leaving a sub-versioned directory" \
+	assertNull "did not switch the Ruby when entering a sub-versioned directory" \
 		   "$RUBY_ROOT"
 }
 


### PR DESCRIPTION
The "[Default Ruby](https://github.com/postmodern/chruby#default-ruby)" section in the Readme indicates that _~/.ruby-version_ would set the default ruby the same way as calling `chruby`. Actually it only sets it for the home directory and its subdirectories.

I'm not sure if this is a problem for anyone, but maybe the wording in the readme should be tweaked a bit? If a true default value is wanted then `chruby_auto` should try to find and use _~/.ruby-version_ as a fallback before resetting to system ruby.
