### PR TITLE
Don't assume rubygems is installed

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -40,16 +40,23 @@ function chruby_use()
 	export PATH="$RUBY_ROOT/bin:$PATH"
 
 	eval `$RUBY_ROOT/bin/ruby - <<EOF
-require 'rubygems'
 puts "export RUBY_ENGINE=#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
 puts "export RUBY_VERSION=#{RUBY_VERSION};"
-puts "export GEM_ROOT=#{Gem.default_dir.inspect};"
+begin
+  require 'rubygems'
+  puts "export GEM_ROOT=#{Gem.default_dir.inspect};"
+rescue LoadError
+end
 EOF`
 
 	if [[ ! $UID -eq 0 ]]; then
 		export GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_VERSION"
-		export GEM_PATH="$GEM_HOME:$GEM_ROOT${GEM_PATH:+:}${GEM_PATH:-}"
-		export PATH="$GEM_HOME/bin:$GEM_ROOT/bin:$PATH"
+		export GEM_PATH="$GEM_HOME"
+		if [[ "$GEM_ROOT" -ne "" ]]; then
+			export GEM_PATH="$GEM_PATH:$GEM_ROOT${GEM_PATH:+:}${GEM_PATH:-}"
+			export PATH="$GEM_ROOT/bin:$PATH"
+		fi
+		export PATH="$GEM_HOME/bin:$PATH"
 	fi
 }
 


### PR DESCRIPTION
I just tried to install a fresh copy of 1.8.7 before, chruby printed an error when I tried to switch to it and didn't set `GEM_HOME` correctly
