### PR TITLE
Update shebang to env bash for compatibility.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # chruby script which installs the latest stable versions of Ruby, JRuby
 # and Rubinius into /opt/rubies.


### PR DESCRIPTION
Change shebang from full path to env for compatibility with distros like FreeBSD that don't have a /bin/bash by default.
