### PR TITLE
use `which bash` instead of $SHELL

### DIFF
--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -33,4 +33,4 @@ if [[ $# -eq 0 ]]; then
 	exit 1
 fi
 
-exec $SHELL -l -i -c "chruby $argv && $*"
+exec `which bash` -i -c "chruby $argv && $*"


### PR DESCRIPTION
If `$SHELL` is dash, it causes an error.

``` sh
/bin/sh: 1: chruby: not found
```

in Debian lenny (and after), `/bin/sh` link to `dash` as default.
