### PR TITLE
Update chruby.rb

### DIFF
--- a/homebrew/chruby.rb
+++ b/homebrew/chruby.rb
@@ -16,6 +16,11 @@ class Chruby < Formula
     ~/.zshenv file:
 
       source #{HOMEBREW_PREFIX}/opt/chruby/share/chruby/chruby.sh
+      
+    Add the following to the ~/.bash_profile file if you intend to start 
+    from a login shell (Terminal's default):
+    
+      source ~/.bashrc
 
     By default chruby will search for Rubies installed into /opt/rubies/ or
     ~/.rubies/. For non-standard installation locations, simply set the RUBIES


### PR DESCRIPTION
Add standard "put source ~/.bashrc in your ~/.bash_profile" advice in homebrew recipe.
If user runs login shell (such as Terminal) and ~/.bash_profile is not sourcing ~/.bashrc (assuming user added ../..chruby.sh source in ~/.bashrc) then chruby will fail to run.
