### PR TITLE
chruby-exec: silence messages like "Using ruby-1.9.3"

### DIFF
--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -33,4 +33,4 @@ if [[ $# -eq 0 ]]; then
 	exit 1
 fi
 
-exec $SHELL -l -i -c "chruby $argv && $*"
+exec $SHELL -l -i -c "chruby $argv >/dev/null && $*"


### PR DESCRIPTION
When I ran the tests for chruby on your commit 2dcf2435dd using `make test`, one of the tests of chruby-exec fails:

```
>>> Running ./test/chruby_exec_test.sh ...
test_chruby_exec_no_arguments
test_chruby_exec_no_command
test_chruby_exec
ASSERT:did change the ruby expected:<1.9.3> but was:<Using ruby-1.9.3
1.9.3>
```

The code for that test is:

```
test_chruby_exec()
{
    local command="ruby -e 'print RUBY_VERSION'"
    local ruby_version=$(chruby-exec "$TEST_RUBY_VERSION" -- $command)

    assertEquals "did change the ruby" "$TEST_RUBY_VERSION" "$ruby_version"
}
```

Apparently, this test is expecting chruby-exec NOT to print out a "Using ruby-1.9.3" line but it did.  That behavior seems a bit annoying to me.  Generally you want your cron jobs to be silent unless there is an error.  I chose to fix chruby-exec to conform to this test.  The way I did that was to pipe the standard output of chruby into `/dev/null`:

```
exec $SHELL -l -i -c "chruby $argv >/dev/null && $*"
```
