### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
-script: make test
+install:
+  - sudo apt-get update -qq
+  - sudo apt-get install shunit2
+
+script:
+  - make test

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -1,4 +1,4 @@
-[[ -z "$SHUNIT2"     ]] && SHUNIT2=$(git rev-parse --show-toplevel)/test/shunit2
+[[ -z "$SHUNIT2"     ]] && SHUNIT2=/usr/share/shunit2/shunit2
 [[ -n "$ZSH_VERSION" ]] && setopt shwordsplit
 
 . ./share/chruby/chruby.sh


### PR DESCRIPTION
- pull in local copy of `shunit2`.
- test helper uses local `shunit2` by default.
- add a `.travis.yml` including `make test` for script value.
