### PR TITLE
add travis-ci build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Changes the current Ruby.
 
+[![Build Status](https://travis-ci.org/postmodern/chruby.png?branch=master)](https://travis-ci.org/postmodern/chruby)
+
 ## Features
 
 * Updates `$PATH`.


### PR DESCRIPTION
This adds a Travis CI build status badge to the README. Obviously, you may not want to pull this in until the RVM situation is under control :)
