### PR TITLE
Source chruby.sh in the subshell

### DIFF
--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+chruby_sh="$(dirname $0)/../share/chruby/chruby.sh"
+source ${chruby_sh}
+
 case "$1" in
 	-h|--help)
 		echo "usage: chruby-exec RUBY [RUBYOPTS] -- COMMAND"
@@ -31,5 +34,4 @@ if [[ $# -eq 0 ]]; then
 	exit 1
 fi
 
-chruby_sh="$(dirname $0)/../share/chruby/chruby.sh"
 exec $SHELL -i -l -c "source \"${chruby_sh}\" && chruby $argv && $*"


### PR DESCRIPTION
Bash doesn't export functions to subshells.  This means that the
`source` call to load chruby.sh in chruby-exec wasn't actually doing
anything useful.

This patch makes chruby-exec source chruby.sh as the last action before
calling the chruby function in the subshell it launches, which
guarantees that it's available even if the user hasn't sourced chruby.sh
in their .bashrc/.zshrc file.
