### PR TITLE
Use glob qualifiers if zsh

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,20 +1,11 @@
 CHRUBY_VERSION="0.3.6"
 
-case "$(basename $SHELL)" in
-	"bash")
-		RUBIES=(
-		`ls -d "$PREFIX"/opt/rubies/* 2>/dev/null`
-		`ls -d "$HOME"/.rubies/* 2>/dev/null`
-		)
-		;;
+[[ -n "$ZSH_NAME" ]] && source $(dirname $0)"/chruby.zsh"
+[[ -z "$ZSH_NAME" ]] && RUBIES=(
+  `ls -d "$PREFIX"/opt/rubies/* 2>/dev/null`
+  `ls -d "$HOME"/.rubies/* 2>/dev/null`
+)
 
-	"zsh")
-		RUBIES=(
-		$PREFIX/opt/rubies/*(N-/)
-		$HOME/.rubies/*(N-/)
-		)
-		;;
-esac
 
 function chruby_reset()
 {

--- a/share/chruby/chruby.zsh
+++ b/share/chruby/chruby.zsh
@@ -1,0 +1,4 @@
+RUBIES=(
+$PREFIX/opt/rubies/*(N-/)
+$HOME/.rubies/*(N-/)
+)


### PR DESCRIPTION
`/usr/local/share/chruby/chruby.sh:4: no matches found: /opt/rubies/*` on zsh.
This pull request fix and improve it by glob-qualifiers.

http://zsh.sourceforge.net/Doc/Release/Expansion.html#Glob-Qualifiers
