### PR TITLE
Remove trailing slashes from RUBIES

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,6 +1,7 @@
 CHRUBY_VERSION="0.3.7"
 
 RUBIES=()
+local dir
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
 	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
 done
@@ -69,6 +70,7 @@ function chruby()
 			local star
 
 			for dir in "${RUBIES[@]}"; do
+				dir="${dir%%/}"
 				if [[ "$dir" == "$RUBY_ROOT" ]]; then star="*"
 				else                                  star=" "
 				fi
@@ -81,6 +83,7 @@ function chruby()
 			local match
 
 			for dir in "${RUBIES[@]}"; do
+				dir="${dir%%/}"
 				[[ "${dir##*/}" == *"$1"* ]] && match="$dir"
 			done
 


### PR DESCRIPTION
I use `zsh` and my `$RUBIES` looks like:

```
/Users/austin/.rubies/ruby-1.9.3-p448/
```

It has to do with some `zsh` option that I have set, but I don't recall which offhand. This change includes two fixes for this and a minor change elsewhere:
- Make `$dir` local when setting `$RUBIES` in the first place. Prevents it from leaking outside of where it's needed.
- The trailing slash prevents Ruby versions from being printed in the `"")` case; remove it on processing.
- The trailing slash prevents a Ruby version from being matched in the `*)` case; remove it on processing.
