### PR TITLE
Rehash whenever Ruby changes.

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -26,7 +26,6 @@ function chruby_reset()
 
 	PATH="${PATH#:}"; PATH="${PATH%:}"
 	unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT
-	hash -r
 }
 
 function chruby_use()
@@ -36,7 +35,7 @@ function chruby_use()
 		return 1
 	fi
 
-	[[ -n "$RUBY_ROOT" ]] && chruby_reset
+	[[ -n "$RUBY_ROOT" ]] && chruby_reset || hash -r
 
 	export RUBY_ROOT="$1"
 	export RUBYOPT="$2"
@@ -55,6 +54,8 @@ EOF
 		export GEM_PATH="$GEM_HOME${GEM_ROOT:+:$GEM_ROOT}${GEM_PATH:+:$GEM_PATH}"
 		export PATH="$GEM_HOME/bin${GEM_ROOT:+:$GEM_ROOT/bin}:$PATH"
 	fi
+
+	hash -r
 }
 
 function chruby()


### PR DESCRIPTION
If changing to a Ruby that has different gems with binaries, the shell does not always recognize those changes, e.g., :

```
  % pry
  zsh: correct 'pry' to 'pr' [nyae]? n
```

chruby_reset() does the right thing by rehashing; this change does the same for  chruby_use().
