### PR TITLE
Link to sudo integration page from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ If you have enabled auto-switching, simply create a `.ruby-version` file:
 
 For instructions on using chruby with other tools, please see the [wiki]:
 
+* [Sudo](https://github.com/postmodern/chruby/wiki/Sudo)
 * [Cron](https://github.com/postmodern/chruby/wiki/Cron)
 * [Capistrano](https://github.com/postmodern/chruby/wiki/Capistrano)
 * [Emacs](https://github.com/arnebrasseur/chruby.el#readme)


### PR DESCRIPTION
In my experience with Phusion Passenger, a lot of users get confused by the fact that sudo nukes $PATH. They come to me asking "why does sudo passenger-status give me this weird error?". A lot of users don't even know what $PATH is.

I'm linking to the sudo integration page from the README in the hope of reducing user confusion.
