### PR TITLE
Make auto.sh work with .ruby-version without a newline

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -4,7 +4,7 @@ function chruby_auto() {
 	local dir="$PWD" version
 
 	until [[ -z "$dir" ]]; do
-		if { read -r version <"$dir/.ruby-version"; } 2>/dev/null; then
+		if { read -r version <"$dir/.ruby-version"; } 2>/dev/null || [[ -n "$version" ]]; then
 			if [[ "$version" == "$RUBY_AUTO_VERSION" ]]; then return
 			else
 				RUBY_AUTO_VERSION="$version"


### PR DESCRIPTION
read -r <".ruby-version" returns 1 for files without a newline.
