### PR TITLE
Support global and user default chruby versions in auto.sh

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -16,9 +16,26 @@ function chruby_auto() {
 		dir="${dir%/*}"
 	done
 
-	if [[ -n "$RUBY_AUTO_VERSION" ]]; then
-		chruby_reset
-		unset RUBY_AUTO_VERSION
+	if [[ -z "$RUBY_AUTO_VERSION" ]]; then
+		if { read -r version <"$HOME/.rubies/version"; } 2>/dev/null; then
+			if [[ "$version" == "$RUBY_AUTO_VERSION" ]]; then return
+			else
+				RUBY_AUTO_VERSION="$version"
+				chruby "$version"
+				return $?
+			fi
+		elif { read -r version <"$CHRUBY_ROOT/version"; } 2>/dev/null; then
+			if [[ "$version" == "$RUBY_AUTO_VERSION" ]]; then return
+			else
+				RUBY_AUTO_VERSION="$version"
+				chruby "$version"
+				return $?
+			fi
+
+		else
+			chruby_reset
+			unset RUBY_AUTO_VERSION
+		fi
 	fi
 }
 

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -121,6 +121,28 @@ function test_chruby_auto_invalid_ruby_version()
 		     "$expected_auto_version" "$RUBY_AUTO_VERSION"
 }
 
+function test_chruby_auto_activate_user_default_version()
+{
+	mkdir -p $HOME/.rubies
+	echo "1.9.3" > $HOME/.rubies/version
+	echo "2.0.0" > "$PREFIX/opt/rubies/version"
+
+	cd $HOME && chruby_auto
+
+	assertEquals "did not select the user version over the system version" \
+		"$test_ruby_root" "$RUBY_ROOT"
+}
+
+function test_chruby_auto_activate_system_default_version()
+{
+	echo "1.9.3" > "$PREFIX/opt/rubies/version"
+
+	cd $HOME && chruby_auto
+
+	assertEquals "did not select the user version over the system version" \
+		"$test_ruby_root" "$RUBY_ROOT"
+}
+
 function tearDown()
 {
 	cd "$PWD"


### PR DESCRIPTION
The current behavior in chruby is to fallback to the system Ruby
if no version has been set explicitly, or through a .ruby-version
file in cases where auto.sh is loaded.

This adds some additional automatic version selection lookups to
only if auto.sh is loaded:
- A .ruby-version file in the PWD or any of its parent directories
  will still have the highest priority.
- If the above condition is not met, but the user has a file at
  $HOME/.rubies/version, that version will be enabled.
- If neither of the above conditions are met, but the system has
  a file at $CHRUBY_ROOT/versions, that version will be enabled.
- If none of the above conditions are met, the system Ruby will
  be enabled.

Because this change introduces only two additional lookups, it is
both pretty low in overhead and backwards-compatible with existing
configurations relying on auto.sh.
