### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ sign: $(PKG)
 	gpg --sign --detach-sign --armor $(PKG)
 	git add $(PKG).asc
 	git commit $(PKG).asc -m "Added PGP signature for v$(VERSION) [ci skip]"
-	git push
+	git push origin master
 
 verify: $(PKG) $(SIG)
 	gpg --verify $(SIG) $(PKG)
@@ -47,9 +47,9 @@ test: test/opt/rubies
 	SHELL=`command -v zsh`  ./test/runner
 
 tag:
-	git push
+	git push origin master
 	git tag -s -m "Releasing $(VERSION)" v$(VERSION)
-	git push --tags
+	git push origin master --tags
 
 release: tag download sign
 


### PR DESCRIPTION
The change is divided in 2 commits so you can discard one if you don't like both. 
- 1st change: skip travis build when adding a PGP signature
- 2nd: specify which branch to push instead of pushing everything.
