### PR TITLE
Update RUBIES every time chruby is run

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,10 +1,16 @@
 CHRUBY_VERSION="0.3.8"
-RUBIES=()
 
-for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
-done
-unset dir
+function chruby_update()
+{
+	RUBIES=()
+
+	for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
+		[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+	done
+	unset dir
+}
+
+chruby_update
 
 function chruby_reset()
 {
@@ -59,6 +65,8 @@ EOF
 
 function chruby()
 {
+	chruby_update
+
 	case "$1" in
 		-h|--help)
 			echo "usage: chruby [RUBY|VERSION|system] [RUBY_OPTS]"


### PR DESCRIPTION
While helping someone get setup with chruby and ruby-install, it wasn't immediately obvious to them that they would have to source their profile or start a new terminal session to see a newly installed ruby. I think that either chruby should detect changes in the directories where Rubies are stored, or ruby-install could update the array after install. The former seems more flexible for different installation methods and manual changes/removal.
