### PR TITLE
Select exact Ruby specified if available.

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -79,10 +79,12 @@ function chruby()
 			;;
 		system) chruby_reset ;;
 		*)
-			local dir match
+			local dir dirname match
 			for dir in "${RUBIES[@]}"; do
 				dir="${dir%%/}"
-				[[ "${dir##*/}" == *"$1"* ]] && match="$dir"
+				dirname="${dir##*/}"
+				[[ "$dirname" == "$1" ]] && match="$dir" && break
+				[[ "$dirname" == *"$1"* ]] && match="$dir"
 			done
 
 			if [[ -z "$match" ]]; then


### PR DESCRIPTION
Partially resolves #233 by selecting exact matches when found. So `chruby 2.1.0` will still match `ruby-2.1.0-rc1` but specifying exactly `chruby ruby-2.1.0` will match `ruby-2.1.0`.
