### PR TITLE
chruby support for a default ruby version

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -17,9 +17,24 @@ function chruby_auto() {
 	done
 
 	if [[ -n "$RUBY_AUTO_VERSION" ]]; then
-		chruby_reset
 		unset RUBY_AUTO_VERSION
+		if [[ -z "$RUBY_DEFAULT_VERSION" ]]; then
+				chruby_reset
+		else
+				chruby_use_default
+		fi
 	fi
+}
+
+function chruby_default() {
+	RUBY_DEFAULT_VERSION="$1"
+	if [[ -z "$RUBY_AUTO_VERSION" ]]; then
+		chruby_use_default
+	fi
+}
+
+function chruby_use_default() {
+	chruby "$RUBY_DEFAULT_VERSION"
 }
 
 if [[ -n "$ZSH_VERSION" ]]; then


### PR DESCRIPTION
After a visit to directory with .ruby-version, chruby picks up correct
ruby version.

But afterwards (when you leave from aforementioned directory to a
directory without .ruby-version) chruby defaults to system ruby (which
is no ruby at all in my case).

It bothered me and my friends so I've created a test implementation of
chruby_default.

My bashrc contains:

``` bash
. /usr/local/share/chruby/chruby.sh
. /usr/local/share/chruby/auto.sh
chruby_default 2.1
```

And it works for me fine.
