### PR TITLE
Support 'chruby -' to switch to previous version

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,15 @@ Switch back to system Ruby:
     $ echo $PATH
     /usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/hal/bin
 
+Switch to previous:
+
+    $ chruby system # system Ruby
+    $ chruby 2.0    # 2.0
+    $ chruby -      # system
+    $ chruby -      # 2.0
+    $ chruby 2.1    # 2.1
+    $ chruby -      # 2.0
+
 Run a command under a Ruby with `chruby-exec`:
 
     $ chruby-exec jruby -- gem update

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -77,7 +77,18 @@ function chruby()
 				echo " $star ${dir##*/}"
 			done
 			;;
-		system) chruby_reset ;;
+		system)
+			export OLD_RUBY_ROOT="${RUBY_ROOT##*/}"
+			chruby_reset
+			;;
+		"-")
+			if [[ -z "$OLD_RUBY_ROOT" ]]; then
+				echo "No previous chruby selected." >&2
+				return 1
+			fi
+			shift
+			chruby "$OLD_RUBY_ROOT" "$*"
+			;;
 		*)
 			local dir match
 			for dir in "${RUBIES[@]}"; do
@@ -91,6 +102,12 @@ function chruby()
 			if [[ -z "$match" ]]; then
 				echo "chruby: unknown Ruby: $1" >&2
 				return 1
+			fi
+
+			if [[ -z "$RUBY_ROOT" ]]; then
+				export OLD_RUBY_ROOT="system"
+			else
+				export OLD_RUBY_ROOT="${RUBY_ROOT##*/}"
 			fi
 
 			shift

--- a/test/chruby_test.sh
+++ b/test/chruby_test.sh
@@ -52,6 +52,27 @@ function test_chruby_system()
 	assertNull "did not reset the Ruby" "$RUBY_ROOT"
 }
 
+function test_chruby_previous()
+{
+	chruby "$test_ruby_version" >/dev/null
+	chruby system >/dev/null
+	chruby -
+
+	assertEquals "did not switch to previous" "$test_ruby_root" "$RUBY_ROOT"
+
+	chruby - >/dev/null
+
+	assertNull "did not reset the Ruby" "$RUBY_ROOT"
+}
+
+function test_chruby_previous_without_prior_switch()
+{
+	unset CHRUBY_PREVIOUS
+	chruby - 2>/dev/null
+
+	assertEquals "did not return 1" 1 $?
+}
+
 function test_chruby_unknown()
 {
 	chruby "does_not_exist" 2>/dev/null


### PR DESCRIPTION
From a discussion at #242, this implements `chruby -` to switch to the previous version.

```
$ chruby system # system Ruby
$ chruby 2.0    # 2.0
$ chruby -      # system
$ chruby -      # 2.0
$ chruby 2.1    # 2.1
$ chruby -      # 2.0
```

I realise that the contributing guidelines say don't add further environment variables, but @postmodern thought `chruby -` was a good idea and I don't think there's a better way to implement this.
