### PR TITLE
Support 'chruby -' to switch to previous version

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ Switch back to system Ruby:
     $ echo $PATH
     /usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/hal/bin
 
+Switch to previous:
+
+    $ chruby system # system Ruby
+    $ chruby 2.0    # 2.0
+    $ chruby -      # system
+    $ chruby -      # 2.0
+    $ chruby 2.1    # 2.1
+    $ chruby -      # 2.0
+
 Run a command under a Ruby with `chruby-exec`:
 
     $ chruby-exec jruby -- gem update

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -75,7 +75,16 @@ function chruby()
 				echo " $star $(basename "$dir")"
 			done
 			;;
-		system) chruby_reset ;;
+		system)
+			export OLD_RUBY_ROOT="${RUBY_ROOT##*/}"
+			chruby_reset
+			;;
+		"-")
+			[[ -z "$OLD_RUBY_ROOT" ]] && return 0
+
+			shift
+			chruby "$OLD_RUBY_ROOT" "$*"
+			;;
 		*)
 			local match
 
@@ -86,6 +95,10 @@ function chruby()
 			if [[ -z "$match" ]]; then
 				echo "chruby: unknown Ruby: $1" >&2
 				return 1
+			fi
+
+			if [[ -z "$RUBY_ROOT" ]]; then export OLD_RUBY_ROOT="system"
+			else                           export OLD_RUBY_ROOT="${RUBY_ROOT##*/}"
 			fi
 
 			shift

--- a/test/chruby_test.sh
+++ b/test/chruby_test.sh
@@ -29,6 +29,27 @@ test_chruby_system()
 	assertNull "did not reset the Ruby" "$RUBY_ROOT"
 }
 
+test_chruby_previous()
+{
+	chruby "$test_ruby_version" >/dev/null
+	chruby system >/dev/null
+	chruby -
+
+	assertEquals "did not switch to previous" "$test_ruby_root" "$RUBY_ROOT"
+
+	chruby - >/dev/null
+
+	assertNull "did not reset the Ruby" "$RUBY_ROOT"
+}
+
+test_chruby_previous_without_prior_switch()
+{
+	unset OLD_RUBY_ROOT
+	chruby - 2>/dev/null
+
+	assertEquals "did not return 0" 0 $?
+}
+
 test_chruby_unknown()
 {
 	chruby "foo" 2>/dev/null


### PR DESCRIPTION
Continuation from #243 to merge into `0.4.0` instead of `master`.
