### PR TITLE
one gemset per .ruby-version file

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -8,6 +8,7 @@ function chruby_auto() {
 			if [[ "$version" == "$RUBY_AUTO_VERSION" ]]; then return
 			else
 				RUBY_AUTO_VERSION="$version"
+				export RUBY_PROJECT_DIR="$dir"
 				chruby "$version"
 				return $?
 			fi

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -51,8 +51,8 @@ EOF
 )"
 
 	if (( $UID != 0 )); then
-		export GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_VERSION"
-		export GEM_PATH="$GEM_HOME${GEM_ROOT:+:$GEM_ROOT}${GEM_PATH:+:$GEM_PATH}"
+    export GEM_HOME="$RUBY_PROJECT_DIR/.gem"
+    export GEM_PATH="$RUBY_PROJECT_DIR/.gem"
 		export PATH="$GEM_HOME/bin${GEM_ROOT:+:$GEM_ROOT/bin}:$PATH"
 	fi
 }


### PR DESCRIPTION
i wanted to have separate gemsets for all of my projects
i modified auto.sh to export the location of the .ruby-version file
and changed chruby.sh to set GEM_PATH and GEM_HOME to use that location
this way i do not have to use chgems at all, all i have to do is make a .ruby-version file in the root of my project (and a Gemfile, and install it with gem install -g Gemfile)

this pull request can not be merged as is
i want your opinion first, if you agree that it is a worthy addition, i can make it mergable

i like the idea to have one program to do one thing only
but this hack was too easy not to do it
