### PR TITLE
Ruby-install v0.4.0

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,7 +60,7 @@ cd "$SRC_DIR"
 #
 # Install ruby-install (https://github.com/postmodern/ruby-install#readme)
 #
-ruby_install_version="0.3.3"
+ruby_install_version="0.4.0"
 
 log "Downloading ruby-install ..."
 wget -O "ruby-install-$ruby_install_version.tar.gz" "https://github.com/postmodern/ruby-install/archive/v$ruby_install_version.tar.gz"


### PR DESCRIPTION
ruby-install v0.3.3 installs ruby 2.1 as 2.1.0-preview2 when there is 2.1.0p0
