### PR TITLE
Just install ruby-install, don't call setup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ with:
 
 ### setup.sh
 
-chruby also includes a `setup.sh` script, which installs chruby and the latest
-releases of [Ruby], [JRuby] and [Rubinius]. Simply run the script as root or 
-via `sudo`:
+chruby also includes a `setup.sh` script, which installs chruby and
+[ruby-install]. Simply run the script as root or via `sudo`:
 
     sudo ./scripts/setup.sh
+
+You can then use `ruby-install` to build the Ruby that you want (see the
+"ruby-install" section for examples).
 
 ### Homebrew
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -69,8 +69,8 @@ log "Extracting ruby-install $ruby_install_version ..."
 tar -xzf "ruby-install-$ruby_install_version.tar.gz"
 cd "ruby-install-$ruby_install_version/"
 
-log "Installing ruby-install and Rubies ..."
-./setup.sh
+log "Installing ruby-install ..."
+make install
 
 #
 # Configuration


### PR DESCRIPTION
Hi, and thanks for `chruby` -- we're using it here at RailsBridge in our VM image to keep things simple. It's worked great.

I'm wondering if you would consider having the setup script _not_ call ruby-install's setup script. We want to use the rest of the setup script to make sure everything is standard, but we only want to build one specific ruby, with a version constraint and build options, to keep build times down and the image that students have to download small.

ruby-install's setup just runs `make install` and then builds 3 different Rubies (with no options or way to pass versions/options in), so I think it's not too inconvenient for users to run `setup.sh` and then choose which Ruby they want to build. I've updated the README to explain this (there's already a section listing different Rubies you can build with ruby-install).

If you don't want to default to this, some way that I could optionally turn off the build step (by passing in an environment variable? I don't know... you could try to pass in information about which Rubies to build in argv but I think it would get complicated) would work for us. Thanks
