### PR TITLE
keep binary compatible gem dir (for ruby 2.1)

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -45,6 +45,7 @@ function chruby_use()
 	eval "$("$RUBY_ROOT/bin/ruby" - <<EOF
 puts "export RUBY_ENGINE=#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
 puts "export RUBY_VERSION=#{RUBY_VERSION};"
+begin; require 'rbconfig'; puts "export RUBY_VERSION=#{RbConfig::CONFIG['ruby_version']};" unless RUBY_VERSION[0] == '1'; rescue; end
 begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue LoadError; end
 EOF
 )"


### PR DESCRIPTION
ruby 2.1.\* are binary compatible - therefore it is not needed to recompile gems when migrating between these versions. So the gem dir should not be different for these versions.

This patches adjusts the `RUBY_VERSION` calculation to be 2.1.0 for all 2.1.\* ruby versions. This results in constant gem dirs and the same behavior as for `rubygems` and the `GEM_ROOT`.

To minimize to risk to break something the adjusted paths are protected by a rescue block and were reexported so that it is ensured that we have an valid `RUBY_VERSION` value afterwards.

Because the `RbConfig::CONFIG['ruby_version']` declared all 1.8.\* as binary compatible this value is not used for 1.8 rubies.

I hope this is the best way to adjust chruby.

I did not add any tests, as the setup scripts fails to download ruby 2.0 an ubuntu 14.04 and to really test this change a ruby 2.1.1 or 2.1.2 is needed. Did I miss something?
