### PR TITLE
sort rubies versions properly

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,22 +1,15 @@
 CHRUBY_VERSION="0.3.8"
 RUBIES=()
-
-if \ls --version >/dev/null 2>&1; then
-  GNU_LS=1
-else
-  GNU_LS=0
-fi
+UNSORTED_RUBIES=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-  if [[ -d "$dir" && -n "$(ls -A "$dir")" ]]; then
-    if [ $GNU_LS == 1 ]; then
-      RUBIES+=($(\ls -dv "$dir"/*))
-    else
-      RUBIES+=("$dir"/*)
-    fi
-  fi
+	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && UNSORTED_RUBIES+=("$dir"/*)
 done
 unset dir
+
+RUBIES=($(for rubie in ${UNSORTED_RUBIES[*]}; do
+ 	echo $rubie
+done | sed 'h; s/-/./g ;; s/.*\///g ;; G ; s/\n/ /' | LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n | awk '{print $2}' ))
 
 function chruby_reset()
 {

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -2,7 +2,7 @@ CHRUBY_VERSION="0.3.8"
 RUBIES=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+  [[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=($(ls -dv "$dir"/*))
 done
 unset dir
 

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,8 +1,20 @@
 CHRUBY_VERSION="0.3.8"
 RUBIES=()
 
+if \ls --version >/dev/null 2>&1; then
+  GNU_LS=1
+else
+  GNU_LS=0
+fi
+
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-  [[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=($(ls -dv "$dir"/*))
+  if [[ -d "$dir" && -n "$(ls -A "$dir")" ]]; then
+    if [ $GNU_LS == 1 ]; then
+      RUBIES+=($(\ls -dv "$dir"/*))
+    else
+      RUBIES+=("$dir"/*)
+    fi
+  fi
 done
 unset dir
 


### PR DESCRIPTION
Having rbx-2.2.9 and rbx-2.2.10 in rubies and specifying "chruby rbx" would choose rbx-2.2.9 because chruby.sh just globs the contents of the rubies directories and so the members of the RUBIES array are sorted in ascii order: rbx-2.2.9 > rbx-2.2.10.

Using ls -v instead sorts the ruby versions properly.