### PR TITLE
Ensure chruby-exec parameters are shell-quoted.

### DIFF
--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -20,7 +20,7 @@ fi
 
 argv=()
 
-for arg in $@; do
+for arg in "$@"; do
 	shift
 
 	if [[ "$arg" == "--" ]]; then break
@@ -33,7 +33,7 @@ if (( $# == 0 )); then
 	exit 1
 fi
 
-command="chruby $argv && $*"
+command="chruby $(printf "%q " "${argv[@]}") && $(printf "%q " "$@")"
 
 if [[ -t 0 ]]; then exec "$SHELL" -i -l -c "$command"
 else                exec "$SHELL"    -l -c "$command"

--- a/test/chruby_exec_test.sh
+++ b/test/chruby_exec_test.sh
@@ -16,8 +16,7 @@ function test_chruby_exec_no_command()
 
 function test_chruby_exec()
 {
-	local command="ruby -e 'print RUBY_VERSION'"
-	local ruby_version=$(chruby-exec "$test_ruby_version" -- $command)
+	local ruby_version=$(chruby-exec "$test_ruby_version" -- ruby -e "print RUBY_VERSION")
 
 	assertEquals "did change the ruby" "$test_ruby_version" "$ruby_version"
 }


### PR DESCRIPTION
- Preserve quotes in chruby-exec command parameters (closes #283).
- Fixes a bug where RUBYOPT options passed to chruby-exec are ignored.
