### PR TITLE
Adds DESTDIR support for easier packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ rpm:
 	rpmbuild -ba rpm/chruby.spec
 
 install:
-	for dir in $(INSTALL_DIRS); do mkdir -p $(PREFIX)/$$dir; done
-	for file in $(INSTALL_FILES); do cp $$file $(PREFIX)/$$file; done
-	mkdir -p $(DOC_DIR)
-	cp -r $(DOC_FILES) $(DOC_DIR)/
+	for dir in $(INSTALL_DIRS); do mkdir -p $(DESTDIR)/$(PREFIX)/$$dir; done
+	for file in $(INSTALL_FILES); do cp $$file $(DESTDIR)/$(PREFIX)/$$file; done
+	mkdir -p $(DESTDIR)/$(DOC_DIR)
+	cp -r $(DOC_FILES) $(DESTDIR)/$(DOC_DIR)/
 
 uninstall:
 	for file in $(INSTALL_FILES); do rm -f $(PREFIX)/$$file; done


### PR DESCRIPTION
- Adds DESTDIR support to the makefile to make for easier packaging. For
  instance this is a required patch to package chruby under pkgsrc.
