### PR TITLE
zsh: switch rubies after changing pwd, not before

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -25,6 +25,9 @@ function chruby_auto() {
 if [[ -n "$ZSH_VERSION" ]]; then
 	if [[ ! "$preexec_functions" == *chruby_auto* ]]; then
 		preexec_functions+=("chruby_auto")
+  fi
+	if [[ ! "$chpwd_functions" == *chruby_auto* ]]; then
+		chpwd_functions+=("chruby_auto")
 	fi
 elif [[ -n "$BASH_VERSION" ]]; then
 	trap '[[ "$BASH_COMMAND" != "$PROMPT_COMMAND" ]] && chruby_auto' DEBUG


### PR DESCRIPTION
I suspect this PR will be rejected as "you misunderstand" or will need improving. Here's the problem I'm trying to solve: `auto.sh` hooks `preexec` to try to set the correct ruby before running a command. If that command is something like `cd`, running before the command means it finds `.ruby-version` from the folder I'm leaving, not from the folder I'm entering.
## Setup
- use zsh
- `mkdir -p switching_test/sub`
- `echo 'ruby-top' > switching_test/.ruby-version`
- `echo 'ruby-sub' > switching_test/sub/.ruby-version`
## Tests
- `cd switching_test`
  - Expected result: `chruby: unknown Ruby: ruby-top`
  - Actual result: no error
- `cd sub`
  - Expected result: `chruby: unknown Ruby: ruby-sub`
  - Actual result: `chruby: unknown Ruby: ruby-top`
## This fix

If we also use the `chpwd` hook, we'll switch rubies a second time when we arrive in the new directory. It's not a perfect fix, but at least the end result is correct.

Imperfections:
- Unnecessary work
- If switching out of a folder with an invalid ruby version, the user will see an error like `chruby: unknown Ruby`, even though we immediately afterwards switch to the right version.
## Misgivings
- You list "does not hook CD" as an anti-feature. Do you consider this hooking CD? It doesn't mess with the actual command; eg, it works with `pushd` and `popd`.
- I'm not sure how to run the tests properly, much less add one; `test/runner` gives me a bunch of errors with backtraces like `/usr/share/shunit2/shunit2:.:129: no such file or directory: /usr/share/shunit2/shunit2 \n test/chruby_auto_test.sh:zsh:130: use 'exit' to exit.` I installed `chruby` with homebrew and it appears to be looking in the installation folder for `shunit2`, but I don't know why.
## Alternate idea

The README describes auto-switching as being useful for "when you `cd` between your different projects". A `chpwd` hook handles exactly that scenario, and the `preexec` hook isn't great for it, because it creates the problem I've described here.

But `preexec` is nice for when you open a new terminal and run a command; it ensures you're on the right Ruby first.

Is that the only scenario we need it for? If so, wouldn't it be more straightforward to find a way to run `chruby_auto` when a new terminal is spawned? Eg, maybe we could use a [`precmd` hook](http://zsh.sourceforge.net/Doc/Release/Functions.html) that removes itself in that shell after running `chruby_auto`, and subsequently leaves it to the `chpwd` hook?

What do you think?
