### PR TITLE
Chruby exec dash

### DIFF
--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -35,8 +35,8 @@ fi
 
 command="chruby $(printf "%q " "${argv[@]}") && $(printf "%q " "$@")"
 
-ABS_SHELL=$(readlink -f $SHELL)
-if [[ ${ABS_SHELL##*/} == "dash" ]]; then
+abs_shell=$(readlink -f $SHELL)
+if [[ ${abs_shell##*/} == "dash" ]]; then
   if which bash &> /dev/null; then
     SHELL="bash"
   elif which zsh &> /dev/null; then

--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -35,6 +35,15 @@ fi
 
 command="chruby $(printf "%q " "${argv[@]}") && $(printf "%q " "$@")"
 
+ABS_SHELL=$(readlink -f $SHELL)
+if [[ ${ABS_SHELL##*/} == "dash" ]]; then
+  if which bash &> /dev/null; then
+    SHELL="bash"
+  elif which zsh &> /dev/null; then
+    SHELL="zsh"
+  fi
+fi
+
 if [[ -t 0 ]]; then exec "$SHELL" -i -l -c "$command"
 else                exec "$SHELL"    -l -c "$command"
 fi

--- a/test/chruby_exec_test.sh
+++ b/test/chruby_exec_test.sh
@@ -21,4 +21,13 @@ function test_chruby_exec()
 	assertEquals "did change the ruby" "$test_ruby_version" "$ruby_version"
 }
 
+function test_chruby_exec_dash()
+{
+	SHELL="/bin/dash"
+	local ruby_version=$(chruby-exec "$test_ruby_version" -- ruby -e "print RUBY_VERSION")
+
+	assertEquals "did change the ruby despite dash" "$test_ruby_version" "$ruby_version"
+}
+
+
 SHUNIT_PARENT=$0 . $SHUNIT2


### PR DESCRIPTION
if chruby-exec is executed and SHELL is somehow equal to dash, use bash or zsh instead.
