### PR TITLE
Fixed RUBYGEMS_GEMDEPS warning.

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -42,6 +42,8 @@ function chruby_use()
 	export RUBYOPT="$2"
 	export PATH="$RUBY_ROOT/bin:$PATH"
 
+	typeset unset RUBYGEMS_GEMDEPS
+
 	eval "$("$RUBY_ROOT/bin/ruby" - <<EOF
 puts "export RUBY_ENGINE=#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
 puts "export RUBY_VERSION=#{RUBY_VERSION};"


### PR DESCRIPTION
Unsets the RUBYGEMS_GEMDEPS environment variable inside the chruby_use() function and restores it when the function completes.

Closes #298.
