### PR TITLE
Separate PREFIX and DESTDIR to allow staged installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PKG_NAME=$(NAME)-$(VERSION)
 PKG=$(PKG_DIR)/$(PKG_NAME).tar.gz
 SIG=$(PKG).asc
 
-PREFIX?=$(DESTDIR)/usr/local
+PREFIX?=/usr/local
 DOC_DIR=$(PREFIX)/share/doc/$(PKG_NAME)
 
 pkg:
@@ -59,13 +59,13 @@ rpm:
 	rpmbuild -ba rpm/chruby.spec
 
 install:
-	for dir in $(INSTALL_DIRS); do mkdir -p $(PREFIX)/$$dir; done
-	for file in $(INSTALL_FILES); do cp $$file $(PREFIX)/$$file; done
-	mkdir -p $(DOC_DIR)
-	cp -r $(DOC_FILES) $(DOC_DIR)/
+	for dir in $(INSTALL_DIRS); do mkdir -p $(DESTDIR)$(PREFIX)/$$dir; done
+	for file in $(INSTALL_FILES); do cp $$file $(DESTDIR)$(PREFIX)/$$file; done
+	mkdir -p $(DESTDIR)$(DOC_DIR)
+	cp -r $(DOC_FILES) $(DESTDIR)$(DOC_DIR)/
 
 uninstall:
-	for file in $(INSTALL_FILES); do rm -f $(PREFIX)/$$file; done
-	rm -rf $(DOC_DIR)
+	for file in $(INSTALL_FILES); do rm -f $(DESTDIR)$(PREFIX)/$$file; done
+	rm -rf $(DESTDIR)$(DOC_DIR)
 
 .PHONY: build download sign verify clean test tag release rpm install uninstall all


### PR DESCRIPTION
According to this https://www.gnu.org/prep/standards/html_node/DESTDIR.html#DESTDIR and this http://www.freebsd.org/doc/en/books/porters-handbook/porting-prefix.html `PREFIX` and `DESTDIR` are related but not connected (like it was with `PREFIX?=$(DESTDIR)/usr/local`).
