### PR TITLE
Allow chruby-exec to set custom RUBIES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ SIG=$(PKG).asc
 PREFIX?=/usr/local
 DOC_DIR=$(PREFIX)/share/doc/$(PKG_NAME)
 
+all:
+
 pkg:
 	mkdir $(PKG_DIR)
 
@@ -37,8 +39,6 @@ verify: $(PKG) $(SIG)
 clean:
 	rm -rf test/opt/rubies
 	rm -f $(PKG) $(SIG)
-
-all: $(PKG) $(SIG)
 
 check:
 	shellcheck share/$(NAME)/*.sh

--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -5,7 +5,7 @@ source "$chruby_sh"
 
 case "$1" in
 	-h|--help)
-		echo "usage: chruby-exec RUBY [RUBYOPTS] -- COMMAND [ARGS...]"
+		echo "usage: chruby-exec RUBY [RUBYOPTS] [\"RUBIES=(...)\"] -- COMMAND [ARGS...]"
 		exit
 		;;
 	-V|--version)
@@ -24,7 +24,9 @@ argv=()
 for arg in "$@"; do
 	shift
 
-	if [[ "$arg" == "--" ]]; then break
+	if echo "$arg" | grep -q '^RUBIES=('; then
+		CUSTOM_RUBIES="$arg"
+	elif [[ "$arg" == "--" ]]; then break
 	else                          argv+=($arg)
 	fi
 done
@@ -38,6 +40,7 @@ shell_opts=("-l")
 [[ -t 0 ]] && shell_opts+=("-i")
 
 source_command="command -v chruby >/dev/null || source $chruby_sh"
+[[ -n "$CUSTOM_RUBIES" ]] && source_command+="; $CUSTOM_RUBIES"
 chruby_command="chruby $(printf "%q " "${argv[@]}")"
 sub_command="$(printf "%q " "$@")"
 command="$source_command; $chruby_command && $sub_command"


### PR DESCRIPTION
`chruby-exec` always sources `chruby.sh`, which nukes `RUBIES` with `RUBIES=()`

This PR add an ability to set RUBIES as another pre-argument for `chruby-exec`

(Tested, works.)
