### PR TITLE
Update test ruby to p481

### DIFF
--- a/benchmarks/chruby_auto.sh
+++ b/benchmarks/chruby_auto.sh
@@ -1,7 +1,7 @@
 root="${0%/*}/.."
 n=100
 
-RUBIES=("$root/test/opt/rubies/ruby-2.0.0-p353")
+RUBIES=("$root/test/opt/rubies/ruby-2.0.0-p481")
 
 . "$root/share/chruby/chruby.sh"
 . "$root/share/chruby/auto.sh"

--- a/benchmarks/chruby_use.sh
+++ b/benchmarks/chruby_use.sh
@@ -1,6 +1,6 @@
 root="${0%/*}/.."
 n=100
-ruby_dir="$root/test/opt/rubies/ruby-2.0.0-p353"
+ruby_dir="$root/test/opt/rubies/ruby-2.0.0-p481"
 
 . "$root/share/chruby/chruby.sh"
 

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -10,7 +10,7 @@ chruby_reset
 
 test_ruby_engine="ruby"
 test_ruby_version="2.0.0"
-test_ruby_patchlevel="353"
+test_ruby_patchlevel="481"
 test_ruby_api="2.0.0"
 test_ruby_root="$PWD/test/opt/rubies/$test_ruby_engine-$test_ruby_version-p$test_ruby_patchlevel"
 


### PR DESCRIPTION
`2.0.0-p353` is no longer available on the rvm servers, which causes `test/setup` to fail.

http://rvm.io/binaries/osx/10.10/x86_64/