### PR TITLE
Adjust version matching

### DIFF
--- a/benchmarks/chruby_auto.sh
+++ b/benchmarks/chruby_auto.sh
@@ -1,7 +1,7 @@
 root="${0%/*}/.."
 n=100
 
-RUBIES=("$root/test/opt/rubies/ruby-2.0.0-p353")
+RUBIES=("$root/test/opt/rubies/ruby-2.0.0-p481")
 
 . "$root/share/chruby/chruby.sh"
 . "$root/share/chruby/auto.sh"

--- a/benchmarks/chruby_use.sh
+++ b/benchmarks/chruby_use.sh
@@ -1,6 +1,6 @@
 root="${0%/*}/.."
 n=100
-ruby_dir="$root/test/opt/rubies/ruby-2.0.0-p353"
+ruby_dir="$root/test/opt/rubies/ruby-2.0.0-p481"
 
 . "$root/share/chruby/chruby.sh"
 

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -58,6 +58,20 @@ EOF
 	fi
 }
 
+function chruby_ruby_select()
+{
+	local dir
+	for dir in "${RUBIES[@]}"; do
+		dir="${dir%%/}"
+		case "${dir##*/}" in
+			"$1") matched_ruby="$dir" && break;;
+			ruby-"$1"*) matched_ruby="$dir";;
+			"$1"*) matched_ruby="$dir";;
+		esac
+	done
+}
+
+
 function chruby()
 {
 	case "$1" in
@@ -80,22 +94,16 @@ function chruby()
 			;;
 		system) chruby_reset ;;
 		*)
-			local dir match
-			for dir in "${RUBIES[@]}"; do
-				dir="${dir%%/}"
-				case "${dir##*/}" in
-					"$1")	match="$dir" && break ;;
-					*"$1"*)	match="$dir" ;;
-				esac
-			done
+			local matched_ruby
+			chruby_ruby_select "$1"
 
-			if [[ -z "$match" ]]; then
+			if [[ -z "$matched_ruby" ]]; then
 				echo "chruby: unknown Ruby: $1" >&2
 				return 1
 			fi
 
 			shift
-			chruby_use "$match" "$*"
+			chruby_use "$matched_ruby" "$*"
 			;;
 	esac
 }

--- a/test/chruby_test.sh
+++ b/test/chruby_test.sh
@@ -68,4 +68,54 @@ function test_chruby_invalid_ruby()
 	assertEquals "did not return 1" 1 $?
 }
 
+function test_chruby_ruby_select_by_major_minor()
+{
+	RUBIES=(
+		/opt/rubies/ruby-2.0.0-p100
+		/opt/rubies/ruby-2.1.0
+		/opt/rubies/ruby-2.2.0
+		/opt/rubies/ruby-2.2.1
+	)
+
+	chruby_ruby_select "2.0"
+	assertEquals "did not match major.minor" "/opt/rubies/ruby-2.0.0-p100" "$matched_ruby"
+
+	chruby_ruby_select "2.1"
+	assertEquals "did not match major.minor" "/opt/rubies/ruby-2.1.0" "$matched_ruby"
+}
+
+function test_chruby_ruby_select_by_implementation()
+{
+	RUBIES=(
+		/opt/rubies/ruby-2.2.10
+		/opt/rubies/rbx-2.2.10
+	)
+
+	chruby_ruby_select "rbx"
+	assertEquals "did not match by implementation" "/opt/rubies/rbx-2.2.10" "$matched_ruby"
+}
+
+function test_chruby_ruby_select_exact()
+{
+	RUBIES=(
+		/opt/rubies/2.1.0
+		/opt/rubies/ruby-2.1.0
+		/opt/rubies/ruby-2.1.1
+	)
+
+	chruby_ruby_select "ruby-2.1.0"
+	assertEquals "did not match exact" "/opt/rubies/ruby-2.1.0" "$matched_ruby"
+}
+
+function test_chruby_ruby_select_last()
+{
+	RUBIES=(
+		/opt/rubies/ruby-1.9.3-p100
+		/opt/rubies/ruby-1.9.3-p200
+	)
+
+	chruby_ruby_select "1.9.3"
+	assertEquals "did not match last version listed" "/opt/rubies/ruby-1.9.3-p200" "$matched_ruby"
+}
+
 SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -10,7 +10,7 @@ chruby_reset
 
 test_ruby_engine="ruby"
 test_ruby_version="2.0.0"
-test_ruby_patchlevel="353"
+test_ruby_patchlevel="481"
 test_ruby_api="2.0.0"
 test_ruby_root="$PWD/test/opt/rubies/$test_ruby_engine-$test_ruby_version-p$test_ruby_patchlevel"
 


### PR DESCRIPTION
This is based off of https://github.com/postmodern/chruby/pull/319

Addresses #318
- Breaks out ruby selection into function for testing.
- Removes `*"$1"*` matching and adds `ruby-"$1"*` and `"$1"*` matching.

For example, given the following:

``` bash
RUBIES=(
  /opt/rubies/ruby-2.0.0-p100
  /opt/rubies/ruby-2.1.1
  /opt/rubies/ruby-2.2.0
  /opt/rubies/ruby-2.2.1
  /opt/rubies/rbx-2.2.0
  /opt/rubies/rbx-2.2.1
)
```
- `chruby ruby-2.2` selects `/opt/rubies/ruby-2.2.1`
- `chruby rbx` selects to `/opt/rubies/rbx-2.2.1`
- `chruby 2.1` selects to `/opt/rubies/ruby-2.1.1`, this is the only change in the current behavior.  In master this would select `/opt/rubies/ruby-2.2.1`
