### PR TITLE
support mruby with no `defined?` method

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -46,7 +46,7 @@ function chruby_use()
 	typeset unset RUBYGEMS_GEMDEPS
 
 	eval "$("$RUBY_ROOT/bin/ruby" - <<EOF
-puts "export RUBY_ENGINE=#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
+puts "export RUBY_ENGINE=#{Object.const_defined?(:RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
 puts "export RUBY_VERSION=#{RUBY_VERSION};"
 begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue LoadError; end
 EOF


### PR DESCRIPTION
Hi,

`mruby` does not provide `defined?` and it looks like it won't mruby/mruby#1696
~~As of Mar 21, 2015, mruby-dev does no support `const_defined?` or `defined?`.~~

~~How about using `rescue` instead of `defined?` to determine `RUBY_ENGINE`.~~
**EDIT:** How about using `Object.const_defined?` to determine `RUBY_ENGINE`

Thanks
--K
