### PR TITLE
Use Exception to catch LoadError

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -46,7 +46,7 @@ function chruby_use()
 	eval "$(RUBYGEMS_GEMDEPS="" "$RUBY_ROOT/bin/ruby" - <<EOF
 puts "export RUBY_ENGINE=#{Object.const_defined?(:RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
 puts "export RUBY_VERSION=#{RUBY_VERSION};"
-begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue LoadError; end
+begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue Exception; end
 EOF
 )"
 	export PATH="${GEM_ROOT:+$GEM_ROOT/bin:}$PATH"


### PR DESCRIPTION
mruby does not define `LoadError` (nor `require`)

This works when I replace the `rescue LoadError` with `rescue`

thanks for this great library
