### PR TITLE
Wrap chruby_auto to ease augmentation (issue #227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ https://gist.github.com/1912050
 
 If you want to automatically run the version of a gem executable specified in 
 your project's Gemfile, try 
-[rubygems-bundler](https://github.com/mpapis/rubygems-bundler).
+[rubygems-bundler](https://github.com/mpapis/rubygems-bundler). If you want to
+modify how and when chruby_auto is called, you may override the
+`ruby_version_autoexec` shell function.
 
 ### Default Ruby
 

--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -24,10 +24,14 @@ function chruby_auto() {
 	fi
 }
 
+function ruby_version_autoexec() {
+	chruby_auto
+}
+
 if [[ -n "$ZSH_VERSION" ]]; then
-	if [[ ! "$preexec_functions" == *chruby_auto* ]]; then
-		preexec_functions+=("chruby_auto")
+	if [[ ! "$preexec_functions" == *ruby_version_autoexec* ]]; then
+		preexec_functions+=("ruby_version_autoexec")
 	fi
 elif [[ -n "$BASH_VERSION" ]]; then
-	trap '[[ "$BASH_COMMAND" != "$PROMPT_COMMAND" ]] && chruby_auto' DEBUG
+	trap '[[ "$BASH_COMMAND" != "$PROMPT_COMMAND" ]] && ruby_version_autoexec' DEBUG
 fi

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -7,35 +7,35 @@ function setUp()
 	unset RUBY_AUTO_VERSION
 }
 
-function test_chruby_auto_loaded_in_zsh()
+function test_ruby_version_autoexec_loaded_in_zsh()
 {
 	[[ -n "$ZSH_VERSION" ]] || return
 
-	assertEquals "did not add chruby_auto to preexec_functions" \
-		     "chruby_auto" \
+	assertEquals "did not add ruby_version_autoexec to preexec_functions" \
+		     "ruby_version_autoexec" \
 		     "$preexec_functions"
 }
 
-function test_chruby_auto_loaded_in_bash()
+function test_ruby_version_autoexec_loaded_in_bash()
 {
 	[[ -n "$BASH_VERSION" ]] || return
 
 	local command=". $PWD/share/chruby/auto.sh && trap -p DEBUG"
 	local output="$("$SHELL" -c "$command")"
 
-	assertTrue "did not add a trap hook for chruby_auto" \
-		   '[[ "$output" == *chruby_auto* ]]'
+	assertTrue "did not add a trap hook for ruby_version_autoexec" \
+		   '[[ "$output" == *ruby_version_autoexec* ]]'
 }
 
-function test_chruby_auto_loaded_twice_in_zsh()
+function test_ruby_version_autoexec_loaded_twice_in_zsh()
 {
 	[[ -n "$ZSH_VERSION" ]] || return
 
 	. ./share/chruby/auto.sh
 
-	assertNotEquals "should not add chruby_auto twice" \
+	assertNotEquals "should not add ruby_version_autoexec twice" \
 		        "$preexec_functions" \
-			"chruby_auto chruby_auto"
+			"ruby_version_autoexec ruby_version_autoexec"
 }
 
 function test_chruby_auto_loaded_twice()


### PR DESCRIPTION
This change implements the proposal in #227 and likely addresses #346 as well.  All tests pass on OS X 10.10.

It occurs to me that this is somewhat of a breaking change for zsh users who expect chruby_auto to be added directly to preexec_functions (for example, the code in [this comment](https://github.com/postmodern/chruby/issues/191#issuecomment-64091397) from issue #191).

