### PR TITLE
Make chruby_reset undo only the changes made by chruby_use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /pkg/*.zip
 /test/opt/rubies
 /test/home/.zcompdump
+/.vagrant/
+test/home/.*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
+Vagrant.configure('2') do |config|
   # vagrant box add debian-wheezy-amd64 https://dl.dropboxusercontent.com/u/67225617/lxc-vagrant/lxc-wheezy64-puppet3-2013-07-27.box
   config.vm.define :debian do |debian|
     debian.vm.box = 'debian-wheezy-amd64'
@@ -30,5 +30,14 @@ Vagrant::Config.run do |config|
   # vagrant box add openbsd-5.2-amd64 https://dl.dropbox.com/s/5ietqc3thdholuh/openbsd-52-64.box
   config.vm.define :openbsd do |openbsd|
     openbsd.vm.box = 'openbsd-5.2-amd64'
+  end
+
+  # docker login quay.io (requires quay.io account)
+  # docker pull quay.io/travisci/travis-ruby
+  config.vm.define :travis do |travis|
+    travis.vm.provider :docker do |d|
+      d.image = 'quay.io/travisci/travis-ruby'
+      d.pull = true
+    end
   end
 end

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,5 +1,10 @@
 CHRUBY_VERSION="0.3.9"
+
 RUBIES=()
+
+unset -v CHRUBY_CACHE
+declare -A CHRUBY_CACHE
+CHRUBY_CACHE=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
 	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
@@ -10,23 +15,68 @@ function chruby_reset()
 {
 	[[ -z "$RUBY_ROOT" ]] && return
 
-	PATH=":$PATH:"; PATH="${PATH//:$RUBY_ROOT\/bin:/:}"
-	[[ -n "$GEM_ROOT" ]] && PATH="${PATH//:$GEM_ROOT\/bin:/:}"
+	function chruby_cache_exists()
+	{
+		[[ -n "${CHRUBY_CACHE[$1]+x}" ]]
+	}
 
-	if (( UID != 0 )); then
-		[[ -n "$GEM_HOME" ]] && PATH="${PATH//:$GEM_HOME\/bin:/:}"
+	function chruby_cache_matches()
+	{
+		[[ "${CHRUBY_CACHE[$1]}" == "$2" ]]
+	}
 
-		GEM_PATH=":$GEM_PATH:"
-		[[ -n "$GEM_HOME" ]] && GEM_PATH="${GEM_PATH//:$GEM_HOME:/:}"
-		[[ -n "$GEM_ROOT" ]] && GEM_PATH="${GEM_PATH//:$GEM_ROOT:/:}"
-		GEM_PATH="${GEM_PATH#:}"; GEM_PATH="${GEM_PATH%:}"
+	function chruby_warn_changed_var()
+	{
+		local var="${1:?variable name is required}"
+		shift
+		local cleanup_message="${1:-doing best-effort cleanup}"
 
-		unset GEM_HOME
-		[[ -z "$GEM_PATH" ]] && unset GEM_PATH
+		printf >&2 -- 'chruby: %s has changed since switching to %s; %s\n' \
+			"$var" "${RUBY_ROOT##*/}" "$cleanup_message"
+	}
+
+	if chruby_cache_exists CHRUBY_PATH; then
+		if chruby_cache_matches CHRUBY_PATH "$PATH"; then
+			PATH="${CHRUBY_CACHE[PATH]}"
+		else
+			chruby_warn_changed_var PATH
+			PATH=":$PATH:"
+			PATH="${PATH/:${CHRUBY_CACHE[ADDED_PATH]}:}"
+		fi
 	fi
 
+	if chruby_cache_exists CHRUBY_GEM_PATH; then
+		if chruby_cache_matches CHRUBY_GEM_PATH "$GEM_PATH"; then
+			GEM_PATH="${CHRUBY_CACHE[GEM_PATH]}"
+		else
+			chruby_warn_changed_var GEM_PATH
+			GEM_PATH=":$GEM_PATH:"
+			GEM_PATH="${GEM_PATH/:${CHRUBY_CACHE[ADDED_GEM_PATH]}:}"
+		fi
+	fi
+
+	if chruby_cache_exists CHRUBY_GEM_HOME; then
+		if chruby_cache_matches CHRUBY_GEM_HOME "$GEM_HOME"; then
+			GEM_HOME="${CHRUBY_CACHE[GEM_HOME]}"
+		else
+			chruby_warn_changed_var GEM_HOME 'leaving as-is'
+		fi
+	fi
+
+	GEM_PATH="${GEM_PATH#:}"; GEM_PATH="${GEM_PATH%:}"
 	PATH="${PATH#:}"; PATH="${PATH%:}"
+
+	export GEM_HOME GEM_PATH PATH
+
+	[[ -z "$GEM_HOME" ]] && unset GEM_HOME
+	[[ -z "$GEM_PATH" ]] && unset GEM_PATH
+
 	unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT
+
+	unset -f chruby_cache_exists chruby_cache_matches chruby_warn_changed_var
+
+	CHRUBY_CACHE=()
+
 	hash -r
 }
 
@@ -39,8 +89,37 @@ function chruby_use()
 
 	[[ -n "$RUBY_ROOT" ]] && chruby_reset
 
+	function chruby_unshift_cache()
+	{
+		local key="$1"
+		local value="$2"
+
+		if [[ -z "$key" ]]; then
+			echo "chruby: cache key required" >&2
+			return 1
+		elif [[ -z "$value" ]]; then
+			return
+		fi
+
+		if (( $# > 2 )); then
+			local stored="${CHRUBY_CACHE[$key]}"
+			CHRUBY_CACHE[$key]="${value}${stored:+${3}$stored}"
+		else
+			CHRUBY_CACHE[$key]="$value"
+		fi
+	}
+
 	export RUBY_ROOT="$1"
 	export RUBYOPT="$2"
+
+	# If the modified GEM_HOME, GEM_PATH, and PATH values we create in this
+	# function haven't changed by the time chruby_reset is called, we'll
+	# restore these cached values.
+	chruby_unshift_cache GEM_HOME "$GEM_HOME"
+	chruby_unshift_cache GEM_PATH "$GEM_PATH"
+	chruby_unshift_cache PATH "$PATH"
+
+	chruby_unshift_cache ADDED_PATH "$RUBY_ROOT/bin" ':'
 	export PATH="$RUBY_ROOT/bin:$PATH"
 
 	eval "$(RUBYGEMS_GEMDEPS="" "$RUBY_ROOT/bin/ruby" - <<EOF
@@ -49,13 +128,36 @@ puts "export RUBY_VERSION=#{RUBY_VERSION};"
 begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue LoadError; end
 EOF
 )"
-	export PATH="${GEM_ROOT:+$GEM_ROOT/bin:}$PATH"
+
+	if [[ -n "$GEM_ROOT" ]]; then
+		chruby_unshift_cache ADDED_PATH "$GEM_ROOT/bin" ':'
+		PATH="$GEM_ROOT/bin:$PATH"
+	fi
 
 	if (( UID != 0 )); then
-		export GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_VERSION"
-		export GEM_PATH="$GEM_HOME${GEM_ROOT:+:$GEM_ROOT}${GEM_PATH:+:$GEM_PATH}"
-		export PATH="$GEM_HOME/bin:$PATH"
+		GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_VERSION"
+
+		for gem_path_to_add in "$GEM_ROOT" "$GEM_HOME"; do
+			if [[ -n "$gem_path_to_add" ]]; then
+				chruby_unshift_cache ADDED_GEM_PATH "$gem_path_to_add" ':'
+				GEM_PATH="${gem_path_to_add}${GEM_PATH:+:$GEM_PATH}"
+			fi
+		done
+
+		chruby_unshift_cache ADDED_PATH "$GEM_HOME/bin" ':'
+		PATH="$GEM_HOME/bin:$PATH"
 	fi
+
+	# Store the values of these variables so that we can check them in
+	# chruby_reset -- if they haven't changed, we simply restore the values of
+	# GEM_HOME, GEM_PATH and PATH that we stored earlier in this function.
+	chruby_unshift_cache CHRUBY_GEM_HOME "$GEM_HOME"
+	chruby_unshift_cache CHRUBY_GEM_PATH "$GEM_PATH"
+	chruby_unshift_cache CHRUBY_PATH "$PATH"
+
+	unset -f chruby_unshift_cache
+
+	export GEM_HOME GEM_PATH PATH
 
 	hash -r
 }

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -1,10 +1,22 @@
 . ./share/chruby/auto.sh
 . ./test/helper.sh
 
+STORED_RUBY_AUTO_VERSION=''
+
 function setUp()
 {
 	chruby_reset
 	unset RUBY_AUTO_VERSION
+}
+
+function oneTimeSetUp()
+{
+	STORED_RUBY_AUTO_VERSION="$(< "$test_project_modified_ruby_version")"
+}
+
+function oneTimeTearDown()
+{
+	echo "$STORED_RUBY_AUTO_VERSION" > "$test_project_modified_ruby_version"
 }
 
 function test_chruby_auto_loaded_in_zsh()
@@ -35,7 +47,7 @@ function test_chruby_auto_loaded_twice_in_zsh()
 
 	assertNotEquals "should not add chruby_auto twice" \
 		        "$preexec_functions" \
-			"chruby_auto chruby_auto"
+		        "chruby_auto chruby_auto"
 }
 
 function test_chruby_auto_loaded_twice()
@@ -84,8 +96,8 @@ function test_chruby_auto_enter_subdir_with_ruby_version()
 
 function test_chruby_auto_modified_ruby_version()
 {
-	cd "$test_project_dir/modified_version" && chruby_auto
-	echo "2.2" > .ruby-version              && chruby_auto
+	cd "${test_project_modified_ruby_version%/*}" && chruby_auto
+	echo "2.2" > .ruby-version                    && chruby_auto
 
 	assertEquals "did not detect the modified .ruby-version file" \
 		     "$test_ruby_root" "$RUBY_ROOT"

--- a/test/chruby_reset_test.sh
+++ b/test/chruby_reset_test.sh
@@ -34,11 +34,13 @@ function test_chruby_reset_env_variables()
 
 function test_chruby_reset_duplicate_path()
 {
-	export PATH="$PATH:$GEM_HOME/bin:$GEM_ROOT/bin:$RUBY_ROOT/bin"
+	duplicated_path="$GEM_HOME/bin:$GEM_ROOT/bin:$RUBY_ROOT/bin"
+	expected_path="$test_path:$duplicated_path"
+	export PATH="$PATH:$duplicated_path"
 
 	chruby_reset
 
-	assertEquals "PATH was not sanitized"    "$test_path" "$PATH"
+	assertEquals "PATH was not sanitized"    "$expected_path" "$PATH"
 }
 
 function test_chruby_reset_modified_gem_path()
@@ -61,6 +63,13 @@ function test_chruby_reset_no_gem_root_or_gem_home()
 	chruby_reset
 
 	assertEquals "PATH was messed up" "$test_path:/bin" "$PATH"
+}
+
+function test_chruby_reset_cache_cleared()
+{
+	chruby_reset
+
+	assertEquals "CHRUBY_CACHE was not cleared" "${#CHRUBY_CACHE[@]}" 0
 }
 
 SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/chruby_use_test.sh
+++ b/test/chruby_use_test.sh
@@ -31,6 +31,41 @@ function test_chruby_use_env_variables()
 		     "$(command -v ruby)"
 }
 
+function test_chruby_use_cache_population()
+{
+	chruby_reset
+
+	local dummy_gem_home="/tmp/dummy/.gem/2.3.0"
+	local dummy_gem_path="/tmp/dummy/.gem/2.3.0:/opt/dummy/gems/2.3.0"
+
+	export GEM_HOME="$dummy_gem_home"
+	export GEM_PATH="$dummy_gem_path"
+
+	chruby_use $test_ruby_root >/dev/null
+
+	assertEquals "did not cache correct ADDED_PATH" \
+		     "${CHRUBY_CACHE[ADDED_PATH]}" \
+		     "$test_gem_home/bin:$test_gem_root/bin:$test_ruby_root/bin"
+
+	assertEquals "did not cache correct CHRUBY_GEM_HOME" \
+		     "${CHRUBY_CACHE[CHRUBY_GEM_HOME]}" "$test_gem_home"
+
+	assertEquals "did not cache correct CHRUBY_GEM_PATH" \
+		     "${CHRUBY_CACHE[CHRUBY_GEM_PATH]}" \
+		     "$test_gem_home:$test_gem_root:$dummy_gem_path"
+
+	assertEquals "did not cache correct GEM_HOME" "${CHRUBY_CACHE[GEM_HOME]}" \
+		     "$dummy_gem_home"
+
+	assertEquals "did not cache correct GEM_PATH" "${CHRUBY_CACHE[GEM_PATH]}" \
+		     "$dummy_gem_path"
+
+	assertEquals "did not cache correct PATH" "${CHRUBY_CACHE[PATH]}" \
+		     "$__shunit_tmpDir:$test_path"
+
+	unset -v GEM_HOME GEM_PATH
+}
+
 function tearDown()
 {
 	chruby_reset

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -18,6 +18,7 @@ test_gem_home="$HOME/.gem/$test_ruby_engine/$test_ruby_version"
 test_gem_root="$test_ruby_root/lib/ruby/gems/$test_ruby_api"
 
 test_project_dir="$PWD/test/project"
+test_project_modified_ruby_version="$test_project_dir/modified_version/.ruby-version"
 
 setUp() { return; }
 tearDown() { return; }

--- a/test/setup
+++ b/test/setup
@@ -25,16 +25,26 @@ function fail() {
 	exit -1
 }
 
-function download() {
-	if command -v wget >/dev/null; then
+if command -v wget >/dev/null; then
+	function check_url() {
+		wget -q --spider "$1"
+	}
+
+	function download() {
 		wget -c -O "$2" "$1"
-	elif command -v curl >/dev/null; then
-		curl -L -C - -o "$2" "$1"
-	else
-		error "Could not find wget or curl"
-		return 1
-	fi
-}
+	}
+elif command -v curl >/dev/null; then
+	function check_url() {
+		curl -f -L --head --output /dev/null --silent --fail "$1"
+	}
+
+	function download() {
+		curl -f -L -C - -o "$2" "$1"
+	}
+else
+	error "Could not find wget or curl"
+	return 1
+fi
 
 function detect_system() {
 	# adapted from RVM: https://github.com/wayneeseguin/rvm/blob/master/scripts/functions/utility_system#L3
@@ -154,18 +164,47 @@ detect_system || fail "Cannot auto-detect system type"
 [[ "$system_version" == "unknown" ]] && fail "Could not detect system version"
 [[ "$system_arch" == "unknown"    ]] && fail "Could not detect system arch"
 
-test_ruby_archive="${test_ruby_engine}-${test_ruby_version}.tar.bz2"
-test_ruby_url="http://rvm.io/binaries/$system_name/$system_version/$system_arch/$test_ruby_archive"
-test_ruby_root="$test_ruby_engine-$test_ruby_version"
+test_ruby="${test_ruby_engine}-${test_ruby_version}"
+test_ruby_archive_basename="${test_ruby}.tar.bz2"
+test_ruby_root_parent="${test_ruby_root%/*}"
+test_ruby_archive="${test_ruby_root_parent}/${test_ruby_archive_basename}"
+test_ruby_url="http://rvm.io/binaries/${system_name}/${system_version}/${system_arch}/${test_ruby_archive_basename}"
 
-mkdir -p "$PREFIX/opt/rubies"
-cd "$PREFIX/opt/rubies"
+function clean_up_test_hierarchy()
+{
+	rm -f "$test_ruby_archive"
+	[[ "$test_ruby_root_parent"/* != "$test_ruby_root_parent/*" ]] \
+	        && rmdir "$test_ruby_root_parent"
+}
 
-log "Downloading $test_ruby_url ..."
-download "$test_ruby_url" "$test_ruby_archive" || fail "Download failed"
+function do_or_fail()
+{
+	local preamble="$1"
+	local fail_message="$2"
 
-log "Unpacking $test_ruby_archive ..."
-tar -xjf "$test_ruby_archive" || fail "Unpacking failed"
+	log "$preamble"
+
+	if ! "$@"; then
+		clean_up_test_hierarchy
+		fail "$fail_message"
+	fi
+}
+
+mkdir -p "${test_ruby_archive%/*}"
+
+trap clean_up_test_hierarchy ERR INT QUIT
+
+do_or_fail "Checking ${test_ruby_url} ..." \
+           "${test_ruby} is not available for your system (${system_name}), arch (${system_arch}) and/or libc (${system_version})" \
+           check_url "$test_ruby_url"
+
+do_or_fail "Downloading $test_ruby_url ..." "Download failed" \
+           download "$test_ruby_url" "$test_ruby_archive"
+
+do_or_fail "Unpacking $test_ruby_archive ..." "Unpacking failed" \
+           tar -C "$test_ruby_root_parent" -xjf "$test_ruby_archive"
+
+trap - ERR INT QUIT
 
 log "Cleaning up ..."
 rm -f "$test_ruby_archive"

--- a/test/setup
+++ b/test/setup
@@ -181,6 +181,7 @@ function do_or_fail()
 {
 	local preamble="$1"
 	local fail_message="$2"
+	shift 2
 
 	log "$preamble"
 


### PR DESCRIPTION
This PR alters how `chruby` handles environment variables in order to make sure that `chruby_reset` undoes only those changes that `chruby` itself has made. Right now, when `chruby` cleans up after itself, it does a pretty thorough reaving of `PATH`, `GEM_HOME`, etc., which can lead to situations like this:

```
$ source chruby.sh
$ export RUBIES=(/usr)
$ chruby usr
# ...much later...
$ chruby system
$ bash -c 'echo ":)"'
bash: bash: command not found
$ /usr/bin/bash -c 'echo ":("'
:(
```

I.e., `chruby_reset` scrubs *all* occurrences of `/usr/bin` from `PATH`, not just those added in `chruby_use`.

The code added in this PR caches the pre-`chruby_use` state of various environment variables, along with other values that represent the changes made by `chruby_use`.  These values are used within `chruby_reset` to 

1. check whether any changes (e.g., additions to `PATH` or `GEM_HOME`) have occurred since `chruby_use` was last invoked, and
2. restore the shell environment to its earlier state, if this is possible.

If `chruby` can't be sure that its cleanup logic will restore the shell environment to its earlier state, it will print a warning to that effect and fall back to default cleanup logic.

---

Because this PR violates the contributors' guide's prohibition on new
environment variables, I will also open a PR for an alternate implementation that uses a function rather than the `CHRUBY_CACHE` global associative array as the oracle for assessing the correctness of the shell environment.

However, the function-based approach is not as reliable as the approach taken here: less state is maintained between `chruby_use` and `chruby_reset`, so the cleanup logic has to do some guesswork about the preexisting shell environment that isn't necessary when the relevant attributes of that previous environment are maintained in `CHRUBY_CACHE`.

I also think that `CHRUBY_CACHE` represents minimal environment pollution -- for instance, it won't show up in `env`/`printenv` nor be inherited by any non-bash/zsh child processes.  Maybe it is okay to make an exception in this case?

---

Also included in this PR:

1. An update to the Vagrantfile that adds Travis' own    `travis-ruby` Docker machine, and
2. Enhancements to the test setup script to automatically clean up `test/opt/rubies` in case the rvm download failed.  Because the Makefile only runs the setup script if the `test/opt/rubies` target doesn't exist, an extant-but-empty directory doesn't trigger a build failure -- instead, the `test` target fails somewhere downstream when the absence of the test Ruby installation causes `chruby` to carp about an `unknown Ruby`.