### PR TITLE
Function-based analog of #379 - Make chruby_reset undo only the changes made by chruby_use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /pkg/*.zip
 /test/opt/rubies
 /test/home/.zcompdump
+/.vagrant/
+test/home/.*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant::Config.run do |config|
+Vagrant.configure('2') do |config|
   # vagrant box add debian-wheezy-amd64 https://dl.dropboxusercontent.com/u/67225617/lxc-vagrant/lxc-wheezy64-puppet3-2013-07-27.box
   config.vm.define :debian do |debian|
     debian.vm.box = 'debian-wheezy-amd64'
@@ -30,5 +30,14 @@ Vagrant::Config.run do |config|
   # vagrant box add openbsd-5.2-amd64 https://dl.dropbox.com/s/5ietqc3thdholuh/openbsd-52-64.box
   config.vm.define :openbsd do |openbsd|
     openbsd.vm.box = 'openbsd-5.2-amd64'
+  end
+
+  # docker login quay.io (requires quay.io account)
+  # docker pull quay.io/travisci/travis-ruby
+  config.vm.define :travis do |travis|
+    travis.vm.provider :docker do |d|
+      d.image = 'quay.io/travisci/travis-ruby'
+      d.pull = true
+    end
   end
 end

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,9 +1,5 @@
 CHRUBY_VERSION="0.3.9"
-
 RUBIES=()
-
-declare -A CHRUBY_CACHE
-CHRUBY_CACHE=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
 	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)

--- a/test/chruby_auto_test.sh
+++ b/test/chruby_auto_test.sh
@@ -1,10 +1,22 @@
 . ./share/chruby/auto.sh
 . ./test/helper.sh
 
+STORED_RUBY_AUTO_VERSION=''
+
 function setUp()
 {
 	chruby_reset
 	unset RUBY_AUTO_VERSION
+}
+
+function oneTimeSetUp()
+{
+	STORED_RUBY_AUTO_VERSION="$(< "$test_project_modified_ruby_version")"
+}
+
+function oneTimeTearDown()
+{
+	echo "$STORED_RUBY_AUTO_VERSION" > "$test_project_modified_ruby_version"
 }
 
 function test_chruby_auto_loaded_in_zsh()
@@ -35,7 +47,7 @@ function test_chruby_auto_loaded_twice_in_zsh()
 
 	assertNotEquals "should not add chruby_auto twice" \
 		        "$preexec_functions" \
-			"chruby_auto chruby_auto"
+		        "chruby_auto chruby_auto"
 }
 
 function test_chruby_auto_loaded_twice()
@@ -84,8 +96,8 @@ function test_chruby_auto_enter_subdir_with_ruby_version()
 
 function test_chruby_auto_modified_ruby_version()
 {
-	cd "$test_project_dir/modified_version" && chruby_auto
-	echo "2.2" > .ruby-version              && chruby_auto
+	cd "${test_project_modified_ruby_version%/*}" && chruby_auto
+	echo "2.2" > .ruby-version                    && chruby_auto
 
 	assertEquals "did not detect the modified .ruby-version file" \
 		     "$test_ruby_root" "$RUBY_ROOT"

--- a/test/chruby_reset_test.sh
+++ b/test/chruby_reset_test.sh
@@ -12,7 +12,7 @@ function setUp()
 }
 
 function with_bad_ruby() {
-	export RUBY_ROOT="$(mktemp --dry-run)"
+	export RUBY_ROOT="/tmp/tmp.${RANDOM}"
 	setUpPATH
 	"$@"
 }

--- a/test/chruby_setup_test.sh
+++ b/test/chruby_setup_test.sh
@@ -1,0 +1,77 @@
+. ./test/helper.sh
+
+function test_chruby_setup_callback_execution()
+{
+	local should_be_1=''
+	function _test_chruby_setup_callback_execution()
+	{
+		should_be_1=1
+		unset -f _test_chruby_setup_callback_execution
+	}
+
+	chruby_setup _test_chruby_setup_callback_execution "$test_ruby_root"
+
+	assertEquals "variable definition incorrect" "$should_be_1" 1
+}
+
+function test_chruby_setup_callback_env()
+{
+	function _test_chruby_setup_callback_env()
+	{
+		assertNotNull "_GEM_HOME was not defined" "$_GEM_HOME"
+		assertNotNull "_GEM_PATH was not defined" "$_GEM_PATH"
+		assertNotNull "_GEM_ROOT was not defined" "$_GEM_ROOT"
+		assertNotNull "_PATH was not defined" "$_PATH"
+		assertNotNull "_RUBYOPT was not defined" "$_RUBYOPT"
+		assertNotNull "_RUBY_ENGINE was not defined" "$_RUBY_ENGINE"
+		assertNotNull "_RUBY_ROOT was not defined" "$_RUBY_ROOT"
+		assertNotNull "_RUBY_VERSION was not defined" "$_RUBY_VERSION"
+
+		unset -f _test_chruby_setup_callback_env
+	}
+
+	chruby_setup _test_chruby_setup_callback_env "$test_ruby_root" \
+		                                     "-I/dummy/lib"
+}
+
+function test_chruby_setup_callback_env_persist()
+{
+	function _test_chruby_setup_callback_env_persist()
+	{
+		: ; # Nothing to see here, folks.
+	}
+
+	chruby_setup _test_chruby_setup_callback_env_persist "$test_ruby_root" \
+		                                             "-I/dummy/lib"
+
+	assertNull "_GEM_HOME remains defined" "$_GEM_HOME"
+	assertNull "_GEM_PATH remains defined" "$_GEM_PATH"
+	assertNull "_GEM_ROOT remains defined" "$_GEM_ROOT"
+	assertNull "_PATH remains defined" "$_PATH"
+	assertNull "_RUBYOPT remains defined" "$_RUBYOPT"
+	assertNull "_RUBY_ENGINE remains defined" "$_RUBY_ENGINE"
+	assertNull "_RUBY_ROOT remains defined" "$_RUBY_ROOT"
+	assertNull "_RUBY_VERSION remains defined" "$_RUBY_VERSION"
+}
+
+function test_chruby_setup_required_parameters()
+{
+	local expected_msg_preamble='chruby: usage: chruby_setup'
+	local actual_msg=''
+	local -a arglists=(
+		''
+		'dummy_callback'
+		'dummy_callback dummy_ruby_root dummy_rubyopt extraneous_arg'
+	)
+
+	# chruby_setup should carp if it receives fewer than 2 arguments or more
+	# than 3.  Note that `$arglist' is unquoted so that the shell expands each
+	# string into multiple parameters.
+	for arglist in "${arglists[@]}"; do
+		actual_msg="$(chruby_setup $arglist 2>&1)"
+		assertTrue "did not receive usage error message" \
+			   '[[ "$actual_msg" == "$expected_msg_preamble"* ]]'
+	done
+}
+
+SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -18,6 +18,7 @@ test_gem_home="$HOME/.gem/$test_ruby_engine/$test_ruby_version"
 test_gem_root="$test_ruby_root/lib/ruby/gems/$test_ruby_api"
 
 test_project_dir="$PWD/test/project"
+test_project_modified_ruby_version="$test_project_dir/modified_version/.ruby-version"
 
 setUp() { return; }
 tearDown() { return; }

--- a/test/setup
+++ b/test/setup
@@ -25,16 +25,26 @@ function fail() {
 	exit -1
 }
 
-function download() {
-	if command -v wget >/dev/null; then
+if command -v wget >/dev/null; then
+	function check_url() {
+		wget -q --spider "$1"
+	}
+
+	function download() {
 		wget -c -O "$2" "$1"
-	elif command -v curl >/dev/null; then
-		curl -L -C - -o "$2" "$1"
-	else
-		error "Could not find wget or curl"
-		return 1
-	fi
-}
+	}
+elif command -v curl >/dev/null; then
+	function check_url() {
+		curl -f -L --head --output /dev/null --silent --fail "$1"
+	}
+
+	function download() {
+		curl -f -L -C - -o "$2" "$1"
+	}
+else
+	error "Could not find wget or curl"
+	return 1
+fi
 
 function detect_system() {
 	# adapted from RVM: https://github.com/wayneeseguin/rvm/blob/master/scripts/functions/utility_system#L3
@@ -154,18 +164,45 @@ detect_system || fail "Cannot auto-detect system type"
 [[ "$system_version" == "unknown" ]] && fail "Could not detect system version"
 [[ "$system_arch" == "unknown"    ]] && fail "Could not detect system arch"
 
-test_ruby_archive="${test_ruby_engine}-${test_ruby_version}.tar.bz2"
-test_ruby_url="http://rvm.io/binaries/$system_name/$system_version/$system_arch/$test_ruby_archive"
-test_ruby_root="$test_ruby_engine-$test_ruby_version"
+test_ruby="${test_ruby_engine}-${test_ruby_version}"
+test_ruby_archive_basename="${test_ruby}.tar.bz2"
+test_ruby_root_parent="${test_ruby_root%/*}"
+test_ruby_archive="${test_ruby_root_parent}/${test_ruby_archive_basename}"
+test_ruby_url="http://rvm.io/binaries/${system_name}/${system_version}/${system_arch}/${test_ruby_archive_basename}"
 
-mkdir -p "$PREFIX/opt/rubies"
-cd "$PREFIX/opt/rubies"
+function clean_up_test_hierarchy() {
+	rm -f "$test_ruby_archive"
+	[[ "$test_ruby_root_parent"/* != "$test_ruby_root_parent/*" ]] \
+	        && rmdir "$test_ruby_root_parent"
+}
 
-log "Downloading $test_ruby_url ..."
-download "$test_ruby_url" "$test_ruby_archive" || fail "Download failed"
+function do_or_fail() {
+	local preamble="$1"
+	local fail_message="$2"
 
-log "Unpacking $test_ruby_archive ..."
-tar -xjf "$test_ruby_archive" || fail "Unpacking failed"
+	log "$preamble"
+
+	if ! "$@"; then
+		clean_up_test_hierarchy
+		fail "$fail_message"
+	fi
+}
+
+mkdir -p "${test_ruby_archive%/*}"
+
+trap clean_up_test_hierarchy ERR INT QUIT
+
+do_or_fail "Checking ${test_ruby_url} ..." \
+           "${test_ruby} is not available for your system (${system_name}), arch (${system_arch}) and/or libc (${system_version})" \
+           check_url "$test_ruby_url"
+
+do_or_fail "Downloading $test_ruby_url ..." "Download failed" \
+           download "$test_ruby_url" "$test_ruby_archive"
+
+do_or_fail "Unpacking $test_ruby_archive ..." "Unpacking failed" \
+           tar -C "$test_ruby_root_parent" -xjf "$test_ruby_archive"
+
+trap - ERR INT QUIT
 
 log "Cleaning up ..."
 rm -f "$test_ruby_archive"

--- a/test/setup
+++ b/test/setup
@@ -179,6 +179,7 @@ function clean_up_test_hierarchy() {
 function do_or_fail() {
 	local preamble="$1"
 	local fail_message="$2"
+	shift 2
 
 	log "$preamble"
 


### PR DESCRIPTION
Related to #379.  Instead of introducing a global associative array for tracking changes to the shell environment, uses the `chruby_setup` function in both `chruby_use` and `chruby_reset` to help provide a consistent "view" of the original and desired (post-`chruby_use`) shell environments.