### PR TITLE
Make chruby-exec exec

### DIFF
--- a/bin/chruby-exec
+++ b/bin/chruby-exec
@@ -40,6 +40,6 @@ shell_opts=("-l")
 source_command="command -v chruby >/dev/null || source $chruby_sh"
 chruby_command="chruby $(printf "%q " "${argv[@]}")"
 sub_command="$(printf "%q " "$@")"
-command="$source_command; $chruby_command && $sub_command"
+command="$source_command; $chruby_command && exec $sub_command"
 
 exec "$SHELL" "${shell_opts[@]}" -c "$command"

--- a/test/chruby_exec_test.sh
+++ b/test/chruby_exec_test.sh
@@ -21,6 +21,18 @@ function test_chruby_exec()
 	assertEquals "did change the ruby" "$test_ruby_version" "$ruby_version"
 }
 
+function test_chruby_exec()
+{
+	# Check to ensure that chruby-exec execs, not forks
+	if [ -n "$ZSH_VERSION" ] ; then
+		local checks=$(echo $$ ; chruby-exec 2.2.1 -- ruby -e "puts Process.ppid")
+	else
+		# We need to check this way because $$ does not return the pid of the subprocess in bash
+		local checks=$(bash -c 'echo $PPID' ; bin/chruby-exec 2.2.1 -- ruby -e "puts Process.ppid")
+	fi
+	assertEquals "execed ruby" $checks
+}
+
 function test_chruby_exec_with_version()
 {
 	local output=$(chruby-exec --version)


### PR DESCRIPTION
Previous, chruby exec would leave a parent bash process around. Now it will exec the ruby command, leaving no parent bash process.

This is important when, for instance, starting ruby processes from upstart. Without this fix, upstart will be tracking the parent bash process, not the child ruby process.

It is also, in my opinion, the correct thing to do. With this change, `chruby-exec` starts your ruby process and gets out of the way. Without this fix, you always have an old `bash` process hanging around.