### PR TITLE
Spec file changes to conform more with Fedora packaging guidelines

### DIFF
--- a/rpm/chruby.spec
+++ b/rpm/chruby.spec
@@ -1,21 +1,12 @@
-%define name chruby
-%define version 0.3.9
-%define release 1
-
-%define buildroot %{_topdir}/BUILDROOT
-
-BuildRoot: %{buildroot}
-Source0: https://github.com/postmodern/%{name}/archive/v%{version}.tar.gz
-Summary: Changes the current Ruby
-Name: %{name}
-Version: %{version}
-Release: %{release}
-License: MIT
-URL: https://github.com/postmodern/chruby#readme
-AutoReqProv: no
-BuildArch: noarch
-
-Source1: chruby_profile.sh
+Name:           chruby
+Version:        0.3.9
+Release:        1%{?dist}
+Summary:        Change current ruby
+License:        MIT
+URL:            https://github.com/postmodern/%{name}
+Source0:        https://github.com/postmodern/%{name}/archive/v%{version}.tar.gz
+Source1:        chruby_profile.sh
+BuildArch:      noarch
 
 %description
 Changes the current Ruby.
@@ -26,17 +17,14 @@ Changes the current Ruby.
 %build
 
 %install
-make install PREFIX=%{buildroot}/usr
-install -D -m 644 %{SOURCE1} $RPM_BUILD_ROOT%{_sysconfdir}/profile.d/chruby.sh
+make install PREFIX=%{buildroot}%{_prefix}
+install -D -p -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/profile.d/chruby.sh
 
 %files
-%defattr(-,root,root)
 %{_bindir}/chruby-exec
-%{_datadir}/%{name}/*
-%config
-%{_sysconfdir}/profile.d/chruby.sh
-%doc
-%{_defaultdocdir}/%{name}-%{version}/*
+%{_datadir}/%{name}/
+%config %{_sysconfdir}/profile.d/chruby.sh
+%doc %{_defaultdocdir}/%{name}-%{version}/
 
 %changelog
 * Sun Nov 23 2014 Postmodern <postmodern.mod3@gmail.com> - 0.3.9-1


### PR DESCRIPTION
Building a source RPM (or even a binary RPM if wanted/needed):

 - `cd chruby/rpm/`
 - `wget https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz`
 - `rpmbuild -bs --define "_sourcedir $(pwd)" --define "_specdir $(pwd)" chruby.spec`