### PR TITLE
Fix SHARE_DIR reference for docs folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SIG=$(PKG).asc
 
 PREFIX?=/usr/local
 SHARE_DIR=$(PREFIX)/share
-DOC_DIR=$(SHARE)/doc/$(PKG_NAME)
+DOC_DIR=$(SHARE_DIR)/doc/$(PKG_NAME)
 
 all:
 


### PR DESCRIPTION
Unless the `SHARE` env var is set, the Makefile will error when trying to create the docs dir with:

```
mkdir: cannot create directory ‘/doc’: Permission denied
```

Seems like a simple mistake.