### PR TITLE
Change options passed to ls on rubies search

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -2,7 +2,7 @@ CHRUBY_VERSION="0.3.9"
 RUBIES=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+	[[ -d "$dir" && -n "$(ls -a "$dir")" ]] && RUBIES+=("$dir"/*)
 done
 unset dir
 


### PR DESCRIPTION
On macOS High Sierra the options to `ls` must be lower case.

Previously when running
`$ source /usr/local/share/chruby/chruby.sh`

would result in
`Unrecognized option: 'A'.`