### PR TITLE
[Uninstall] Only remove chruby folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,6 @@ install:
 uninstall:
 	for file in $(INSTALL_FILES); do rm -f $(DESTDIR)$(PREFIX)/$$file; done
 	rm -rf $(DESTDIR)$(DOC_DIR)
-	rmdir $(DESTDIR)$(SHARE_DIR)
+	rmdir $(DESTDIR)$(SHARE_DIR)/chruby
 
 .PHONY: build download sign verify clean check test tag release rpm install uninstall all


### PR DESCRIPTION
Right now my `/usr/local/share` folder contains other files, so when I ran `sudo make uninstall` it errors:

```
$ sudo make uninstall
for file in `find etc lib bin sbin share -type f 2>/dev/null`; do rm -f /usr/local/$file; done
rm -rf /usr/local/share/doc/chruby-0.3.9
rmdir /usr/local/share/chruby
rmdir: /usr/local/share/chruby: Not a directory
make: *** [uninstall] Error 1
```

This Pull Request only removes `/usr/local/share/chruby` folder.