### PR TITLE
Use `command ls`, in case ls is an alias

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -2,7 +2,7 @@ CHRUBY_VERSION="0.3.9"
 RUBIES=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+	[[ -d "$dir" && -n "$(command ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
 done
 unset dir
 


### PR DESCRIPTION
This is perhaps an edgecase, but if ls is an alias/function it's possible that the output is not as expected, leading to failures.