### PR TITLE
Use RUBY_ENGINE_VERSION to decide the GEM_HOME

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,13 @@
+### 0.4.0
+
+#### chruby.sh
+
+* Use `RUBY_ENGINE_VERSION` for setting `GEM_HOME`. (@eregon)  
+  This makes no change for MRI, but it guarantees a unique `GEM_HOME` per
+  release for other Ruby implementations, which is safer for
+  C and JRuby extensions. In practice, updating `chruby` means you will
+  need to install gems again on other Ruby implementations than MRI.
+
 ### 0.3.9 / 2014-11-23
 
 #### chruby.sh

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Changes the current Ruby.
 * Updates `$PATH`.
   * Also adds RubyGems `bin/` directories to `$PATH`.
 * Correctly sets `$GEM_HOME` and `$GEM_PATH`.
-  * Users: gems are installed into `~/.gem/$ruby/$version`.
+  * Users: gems are installed into `~/.gem/$RUBY_ENGINE/$RUBY_ENGINE_VERSION`.
   * Root: gems are installed directly into `/path/to/$ruby/$gemdir`.
 * Additionally sets `$RUBY_ROOT`, `$RUBY_ENGINE`, `$RUBY_VERSION` and
   `$GEM_ROOT`.
@@ -217,9 +217,9 @@ If you have enabled auto-switching, simply create a `.ruby-version` file:
 ### RubyGems
 
 Gems installed as a non-root user via `gem install` will be installed into
-`~/.gem/$ruby/X.Y.Z`.  By default, RubyGems will use the absolute path to the
-currently selected ruby for the shebang of any binstubs it generates.  In some
-cases, this path may contain extra version information (e.g.
+`~/.gem/$RUBY_ENGINE/$RUBY_ENGINE_VERSION`.  By default, RubyGems will use the
+absolute path to the currently selected ruby for the shebang of any binstubs it
+generates.  In some cases, this path may contain extra version information (e.g.
 `ruby-2.0.0-p451`).  To mitigate potential problems when removing rubies, you
 can force RubyGems to generate binstubs with shebangs that will search for
 ruby in your `$PATH` by using `gem install --env-shebang` (or the equivalent

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -26,7 +26,7 @@ function chruby_reset()
 	fi
 
 	PATH="${PATH#:}"; PATH="${PATH%:}"
-	unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBYOPT GEM_ROOT
+	unset RUBY_ROOT RUBY_ENGINE RUBY_VERSION RUBY_ENGINE_VERSION RUBYOPT GEM_ROOT
 	hash -r
 }
 
@@ -46,13 +46,14 @@ function chruby_use()
 	eval "$(RUBYGEMS_GEMDEPS="" "$RUBY_ROOT/bin/ruby" - <<EOF
 puts "export RUBY_ENGINE=#{Object.const_defined?(:RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"
 puts "export RUBY_VERSION=#{RUBY_VERSION};"
+puts "export RUBY_ENGINE_VERSION=#{Object.const_defined?(:RUBY_ENGINE_VERSION) ? RUBY_ENGINE_VERSION : RUBY_VERSION};"
 begin; require 'rubygems'; puts "export GEM_ROOT=#{Gem.default_dir.inspect};"; rescue LoadError; end
 EOF
 )"
 	export PATH="${GEM_ROOT:+$GEM_ROOT/bin:}$PATH"
 
 	if (( UID != 0 )); then
-		export GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_VERSION"
+		export GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_ENGINE_VERSION"
 		export GEM_PATH="$GEM_HOME${GEM_ROOT:+:$GEM_ROOT}${GEM_PATH:+:$GEM_PATH}"
 		export PATH="$GEM_HOME/bin:$PATH"
 	fi


### PR DESCRIPTION
* Such that each installed Ruby has its own `GEM_HOME`, even if `RUBY_VERSION` remains the same for multiple releases of a non-MRI Ruby implementation.
* This is particularly important for TruffleRuby, where different releases with the same `RUBY_VERSION` might compile C extensions differently, and each release should have a different `GEM_HOME`.

cc @postmodern @havenwood 