### PR TITLE
fix invald `ls -A` change to `ls -a`

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -2,7 +2,7 @@ CHRUBY_VERSION="0.3.9"
 RUBIES=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+	[[ -d "$dir" && -n "$(ls -a "$dir")" ]] && RUBIES+=("$dir"/*)
 done
 unset dir
 


### PR DESCRIPTION
Recently a lot of people (myself included) are using the lsd replacement of ls. It is common to alias ls=lsd.

When you do this lsd complains about the ls -A used here:

![image](https://user-images.githubusercontent.com/634562/58109186-00cf1300-7ba2-11e9-9560-3320a70ed77e.png)


![image](https://user-images.githubusercontent.com/634562/58109137-ebf27f80-7ba1-11e9-802a-516add3c0cf1.png)

This PR simply replaces this with ls -a
