### PR TITLE
Use the Ruby directory basename to decide the GEM_HOME

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,8 +4,11 @@
 
 * When updating from `chruby` < 1.0 to `chruby` >= 1.0, you will need to
   re-install your gems because the gem directories will be different. It is also
-  recommended to clean old gem directories which will no longer be used with
-  `rm -rf ~/.gem`.
+  recommended to clean old gem directories under `~/.gem` which will no longer
+  be used to save disk space. If you only ever installed gems with `chruby` then
+  a straightforward `rm -rf ~/.gem` should be fine. Otherwise, look at
+  directories under `~/.gem` and if they look like
+  `~/.gem/$ruby_engine/$ruby_version` they are most likely from chruby.
 
 #### chruby.sh
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,18 @@
+### 1.0.0
+
+#### chruby.sh
+
+* Use the installed Ruby directory name for setting `GEM_HOME`. (@eregon)  
+  This guarantees a unique `GEM_HOME` per installed Ruby, even if they have
+  the same `RUBY_VERSION`.  This is important for native extensions, which
+  might compile differently based on build-time flags such as `--enable-shared`.
+  This also fixes the bug that the `GEM_HOME` for non-MRI Ruby implementations
+  was shared even for different releases.
+
+  In practice, updating `chruby` means you will need to install gems again as
+  the gem directories will be different. It is also recommended to clean old
+  gem directories which will no longer by used with `rm -rf ~/.gem`.
+
 ### 0.3.9 / 2014-11-23
 
 #### chruby.sh

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,10 +5,8 @@
 * When updating from `chruby` < 1.0 to `chruby` >= 1.0, you will need to
   re-install your gems because the gem directories will be different. It is also
   recommended to clean old gem directories under `~/.gem` which will no longer
-  be used to save disk space. If you only ever installed gems with `chruby` then
-  a straightforward `rm -rf ~/.gem` should be fine. Otherwise, look at
-  directories under `~/.gem` and if they look like
-  `~/.gem/$ruby_engine/$ruby_version` they are most likely from chruby.
+  be used to save disk space. To remove them, you can use
+  `rm -rf ~/.gem/{ruby,jruby,rbx,truffleruby}/[0-9].[0-9].[0-9]`
 
 #### chruby.sh
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 ### 1.0.0
 
+#### Upgrade Notes
+
+* When updating from `chruby` < 1.0 to `chruby` >= 1.0, you will need to
+  re-install your gems because the gem directories will be different. It is also
+  recommended to clean old gem directories which will no longer be used with
+  `rm -rf ~/.gem`.
+
 #### chruby.sh
 
 * Use the installed Ruby directory name for setting `GEM_HOME`. (@eregon)  
@@ -8,10 +15,6 @@
   might compile differently based on build-time flags such as `--enable-shared`.
   This also fixes the bug that the `GEM_HOME` for non-MRI Ruby implementations
   was shared even for different releases.
-
-  In practice, updating `chruby` means you will need to install gems again as
-  the gem directories will be different. It is also recommended to clean old
-  gem directories which will no longer by used with `rm -rf ~/.gem`.
 
 ### 0.3.9 / 2014-11-23
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Changes the current Ruby.
 * Updates `$PATH`.
   * Also adds RubyGems `bin/` directories to `$PATH`.
 * Correctly sets `$GEM_HOME` and `$GEM_PATH`.
-  * Users: gems are installed into `~/.gem/$ruby/$version`.
+  * Users: gems are installed into `~/.gem/$(basename /path/to/$ruby)`.
   * Root: gems are installed directly into `/path/to/$ruby/$gemdir`.
 * Additionally sets `$RUBY_ROOT`, `$RUBY_ENGINE`, `$RUBY_VERSION` and
   `$GEM_ROOT`.
@@ -217,13 +217,13 @@ If you have enabled auto-switching, simply create a `.ruby-version` file:
 ### RubyGems
 
 Gems installed as a non-root user via `gem install` will be installed into
-`~/.gem/$ruby/X.Y.Z`.  By default, RubyGems will use the absolute path to the
-currently selected ruby for the shebang of any binstubs it generates.  In some
-cases, this path may contain extra version information (e.g.
+`~/.gem/$(basename /path/to/$ruby)`.  By default, RubyGems will use the
+absolute path to the currently selected ruby for the shebang of any binstubs it
+generates.  In some cases, this path may contain extra version information (e.g.
 `ruby-2.0.0-p451`).  To mitigate potential problems when removing rubies, you
 can force RubyGems to generate binstubs with shebangs that will search for
 ruby in your `$PATH` by using `gem install --env-shebang` (or the equivalent
-short option `-E`).  This parameter can also be added to your gemrc file.
+short option `-E`).  This parameter can also be added to your `.gemrc` file.
 
 ### Integration
 
@@ -268,7 +268,7 @@ Select a Ruby:
         - ruby
         - x86_64-linux
       - GEM PATHS:
-         - /home/hal/.gem/ruby/1.9.3
+         - /home/hal/.gem/ruby-1.9.3-p392
          - /opt/rubies/ruby-1.9.3-p392/lib/ruby/gems/1.9.1
       - GEM CONFIGURATION:
          - :update_sources => true

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Changes the current Ruby.
 * Updates `$PATH`.
   * Also adds RubyGems `bin/` directories to `$PATH`.
 * Correctly sets `$GEM_HOME` and `$GEM_PATH`.
-  * Users: gems are installed into `~/.gem/$(basename /path/to/$ruby)`.
-  * Root: gems are installed directly into `/path/to/$ruby/$gemdir`.
+  * Users: gems are installed into `~/.gem/$ruby_name` (e.g., `~/.gem/ruby-2.6.3` for `~/.rubies/ruby-2.6.3`).
+  * Root: gems are installed directly into `$ruby_install_dir/$gemdir` (the default).
 * Additionally sets `$RUBY_ROOT`, `$RUBY_ENGINE`, `$RUBY_VERSION` and
   `$GEM_ROOT`.
 * Optionally sets `$RUBYOPT` if second argument is given.
@@ -217,7 +217,7 @@ If you have enabled auto-switching, simply create a `.ruby-version` file:
 ### RubyGems
 
 Gems installed as a non-root user via `gem install` will be installed into
-`~/.gem/$(basename /path/to/$ruby)`.  By default, RubyGems will use the
+`~/.gem/$ruby_name`.  By default, RubyGems will use the
 absolute path to the currently selected ruby for the shebang of any binstubs it
 generates.  In some cases, this path may contain extra version information (e.g.
 `ruby-2.0.0-p451`).  To mitigate potential problems when removing rubies, you

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -52,7 +52,7 @@ EOF
 	export PATH="${GEM_ROOT:+$GEM_ROOT/bin:}$PATH"
 
 	if (( UID != 0 )); then
-		export GEM_HOME="$HOME/.gem/$RUBY_ENGINE/$RUBY_VERSION"
+		export GEM_HOME="$HOME/.gem/${RUBY_ROOT##*/}"
 		export GEM_PATH="$GEM_HOME${GEM_ROOT:+:$GEM_ROOT}${GEM_PATH:+:$GEM_PATH}"
 		export PATH="$GEM_HOME/bin:$PATH"
 	fi

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -14,7 +14,7 @@ test_ruby_api="2.2.0"
 test_ruby_root="$PWD/test/opt/rubies/$test_ruby_engine-$test_ruby_version"
 
 test_path="$PATH"
-test_gem_home="$HOME/.gem/$test_ruby_engine/$test_ruby_version"
+test_gem_home="$HOME/.gem/$test_ruby_engine-$test_ruby_version"
 test_gem_root="$test_ruby_root/lib/ruby/gems/$test_ruby_api"
 
 test_project_dir="$PWD/test/project"


### PR DESCRIPTION
* Such that each installed Ruby has its own GEM_HOME, even if RUBY_VERSION
  is the same for multiple installed Rubies.
* This is particularly important for TruffleRuby, where different releases
  with the same RUBY_VERSION might compile C extensions differently, and
  each release should have a different GEM_HOME.

This is the better version of https://github.com/postmodern/chruby/pull/410, discussed in that PR starting from https://github.com/postmodern/chruby/pull/410#issuecomment-509155061

I believe this is the right fix for always setting `GEM_HOME` correctly to a separate directory per Ruby installation.

I added an entry in the changelog along with upgrade notes.
I also updated the README.

Fixes https://github.com/oracle/truffleruby/issues/1723.

@postmodern @havenwood What do you think? Could we merge this?