### PR TITLE
Use bash globbing to set RUBIES

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,10 +1,23 @@
 CHRUBY_VERSION="0.3.9"
 RUBIES=()
 
-for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
-done
-unset dir
+function chruby_rubies()
+{
+	if [ -n "$ZSH_VERSION" ]; then
+		setopt local_options nodotglob nullglob
+	else
+		trap "$(shopt -p dotglob nullglob)" RETURN
+		shopt -u dotglob
+		shopt -s nullglob
+	fi
+
+	local dir
+	for dir in "$@"; do
+		[[ -d "$dir" ]] && RUBIES+=("$dir"/*)
+	done
+}
+chruby_rubies "$PREFIX/opt/rubies" "$HOME/.rubies"
+unset -f chruby_rubies
 
 function chruby_reset()
 {


### PR DESCRIPTION
This is an alternative to #406. It fixes #413 and uses bash native functionality instead of `ls` at all. The impetus for this change is that an alias to `ls` breaks `chruby`. Specifically in my case I have:

```sh
alias ls=exa
```

Which doesn't have a `-A` flag.