### PR TITLE
Set GEM_HOME only if needed, i.e., if Gem.default_dir is not writable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,11 @@
 
 #### chruby.sh
 
+* Only set `GEM_HOME` if needed, that is if `Gem.default_dir` is not writable. (@eregon)  
+  This means the default gem home is used if writable and the Ruby installation
+  contains its gems. Deleting that Ruby will therefore automatically remove the
+  related gems as well. This also avoids gem sharing issues when executing
+  another Ruby directly without changing to it with `chruby` first.
 * Use the installed Ruby directory name for setting `GEM_HOME`. (@eregon)  
   This guarantees a unique `GEM_HOME` per installed Ruby, even if they have
   the same `RUBY_VERSION`.  This is important for native extensions, which

--- a/README.md
+++ b/README.md
@@ -232,47 +232,55 @@ For instructions on using chruby with other tools, please see the [wiki]:
 List available Rubies:
 
     $ chruby
-       ruby-1.9.3-p392
-       jruby-1.7.0
-       rubinius-2.0.0-rc1
+       ruby-2.6.6
+       jruby-9.2.11.0
+       truffleruby-20.0.0
 
 Select a Ruby:
 
-    $ chruby 1.9.3
+    $ chruby 2.6.6
     $ chruby
-     * ruby-1.9.3-p392
-       jruby-1.7.0
-       rubinius-2.0.0-rc1
+     * ruby-2.6.6
+       jruby-9.2.11.0
+       truffleruby-20.0.0
     $ echo $PATH
-    /home/hal/.gem/ruby/1.9.3/bin:/opt/rubies/ruby-1.9.3-p392/lib/ruby/gems/1.9.1/bin:/opt/rubies/ruby-1.9.3-p392/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/home/hal/bin:/home/hal/bin
+    /home/hal/.rubies/ruby-2.6.5/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/hal/bin
     $ gem env
     RubyGems Environment:
-      - RUBYGEMS VERSION: 1.8.23
-      - RUBY VERSION: 1.9.3 (2013-02-22 patchlevel 392) [x86_64-linux]
-      - INSTALLATION DIRECTORY: /home/hal/.gem/ruby/1.9.3
-      - RUBY EXECUTABLE: /opt/rubies/ruby-1.9.3-p392/bin/ruby
-      - EXECUTABLE DIRECTORY: /home/hal/.gem/ruby/1.9.3/bin
+      - RUBYGEMS VERSION: 3.0.3
+      - RUBY VERSION: 2.6.6 (2020-03-31 patchlevel 146) [x86_64-linux]
+      - INSTALLATION DIRECTORY: /home/hal/.rubies/ruby-2.6.6/lib/ruby/gems/2.6.0
+      - USER INSTALLATION DIRECTORY: /home/hal/.gem/ruby/2.6.0
+      - RUBY EXECUTABLE: /home/hal/.rubies/ruby-2.6.6/bin/ruby
+      - GIT EXECUTABLE: /usr/bin/git
+      - EXECUTABLE DIRECTORY: /home/hal/.rubies/ruby-2.6.6/bin
+      - SPEC CACHE DIRECTORY: /home/hal/.gem/specs
+      - SYSTEM CONFIGURATION DIRECTORY: /home/hal/.rubies/ruby-2.6.6/etc
       - RUBYGEMS PLATFORMS:
         - ruby
         - x86_64-linux
       - GEM PATHS:
-         - /home/hal/.gem/ruby-1.9.3-p392
-         - /opt/rubies/ruby-1.9.3-p392/lib/ruby/gems/1.9.1
+         - /home/hal/.rubies/ruby-2.6.6/lib/ruby/gems/2.6.0
+         - /home/hal/.gem/ruby/2.6.0
       - GEM CONFIGURATION:
          - :update_sources => true
          - :verbose => true
-         - :benchmark => false
          - :backtrace => false
          - :bulk_threshold => 1000
-         - "gem" => "--no-rdoc"
+         - "gem" => "--no-document"
       - REMOTE SOURCES:
-         - http://rubygems.org/
+         - https://rubygems.org/
 
-Switch to JRuby in 1.9 mode:
 
-    $ chruby jruby --1.9
+Switch to JRuby in `--dev` mode:
+
+    $ chruby jruby --dev
+    $ chruby
+       ruby-2.6.6
+     * jruby-9.2.11.0 --dev
+       truffleruby-20.0.0
     $ ruby -v
-    jruby 1.7.0 (1.9.3p203) 2012-10-22 ff1ebbe on OpenJDK 64-Bit Server VM 1.7.0_09-icedtea-mockbuild_2012_10_17_15_53-b00 [linux-amd64]
+    jruby 9.2.11.0 (2.5.7) 2020-03-02 612d7a05a6 OpenJDK 64-Bit Server VM ... +jit [linux-x86_64]
 
 Switch back to system Ruby:
 

--- a/README.md
+++ b/README.md
@@ -213,17 +213,6 @@ If you have enabled auto-switching, simply create a `.ruby-version` file:
 
     echo "ruby-1.9" > ~/.ruby-version
 
-### RubyGems
-
-Gems installed as a non-root user via `gem install` will be installed into
-`~/.gem/$ruby_name`.  By default, RubyGems will use the
-absolute path to the currently selected ruby for the shebang of any binstubs it
-generates.  In some cases, this path may contain extra version information (e.g.
-`ruby-2.0.0-p451`).  To mitigate potential problems when removing rubies, you
-can force RubyGems to generate binstubs with shebangs that will search for
-ruby in your `$PATH` by using `gem install --env-shebang` (or the equivalent
-short option `-E`).  This parameter can also be added to your `.gemrc` file.
-
 ### Integration
 
 For instructions on using chruby with other tools, please see the [wiki]:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Changes the current Ruby.
 
 * Updates `$PATH`.
   * Also adds RubyGems `bin/` directories to `$PATH`.
-* Correctly sets `$GEM_HOME` and `$GEM_PATH`.
-  * Users: gems are installed into `~/.gem/$ruby_name` (e.g., `~/.gem/ruby-2.6.3` for `~/.rubies/ruby-2.6.3`).
-  * Root: gems are installed directly into `$ruby_install_dir/$gemdir` (the default).
-* Additionally sets `$RUBY_ROOT`, `$RUBY_ENGINE`, `$RUBY_VERSION` and
-  `$GEM_ROOT`.
+* Sets `$GEM_HOME` and `$GEM_PATH` only if needed:
+  * When the default gem directory is writable: gems are installed directly into it (`$GEM_HOME`/`$GEM_PATH` are not set).
+  * When it is not writable: gems are installed into `~/.gem/$ruby_name` (e.g., `~/.gem/ruby-2.6.5` for `~/.rubies/ruby-2.6.5`).
+* Additionally sets `$RUBY_ROOT`, `$RUBY_ENGINE`, `$RUBY_VERSION` and `$GEM_ROOT`.
 * Optionally sets `$RUBYOPT` if second argument is given.
 * Calls `hash -r` to clear the command-lookup hash-table.
 * Fuzzy matching of Rubies by name.

--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -34,7 +34,7 @@ function chruby_reset()
 	PATH=":$PATH:"; PATH="${PATH//:$RUBY_ROOT\/bin:/:}"
 	[[ -n "$GEM_ROOT" ]] && PATH="${PATH//:$GEM_ROOT\/bin:/:}"
 
-	if (( UID != 0 )); then
+	if [[ ! -w "$GEM_ROOT" ]]; then
 		[[ -n "$GEM_HOME" ]] && PATH="${PATH//:$GEM_HOME\/bin:/:}"
 
 		GEM_PATH=":$GEM_PATH:"
@@ -74,7 +74,7 @@ EOF
 )"
 	export PATH="${GEM_ROOT:+$GEM_ROOT/bin:}$PATH"
 
-	if (( UID != 0 )); then
+	if [[ ! -w "$GEM_ROOT" ]]; then
 		export GEM_HOME="$HOME/.gem/rubies/${RUBY_ROOT##*/}"
 		export GEM_PATH="$GEM_HOME${GEM_ROOT:+:$GEM_ROOT}${GEM_PATH:+:$GEM_PATH}"
 		export PATH="$GEM_HOME/bin:$PATH"

--- a/test/chruby_reset_test.sh
+++ b/test/chruby_reset_test.sh
@@ -2,42 +2,34 @@
 
 function setUp()
 {
+	chmod u-w "$test_gem_root"
 	chruby_use "$test_ruby_root" >/dev/null
 
 	export PATH="$GEM_HOME/bin:$GEM_ROOT/bin:$RUBY_ROOT/bin:$test_path"
 }
 
+function tearDown()
+{
+	chmod u+w "$test_gem_root"
+}
+
 function test_chruby_reset_hash_table()
 {
-	if [[ -n "$BASH_VERSION" ]]; then
-		assertEquals "did not clear the path table" \
-			     "hash: hash table empty" "$(hash)"
-	elif [[ -n "$ZSH_VERSION" ]]; then
-		assertEquals "did not clear the path table" \
-			     "" "$(hash)"
-	fi
+	chruby_reset
+	assertClearPathTable
 }
 
 function test_chruby_reset_env_variables()
 {
 	chruby_reset
-
-	assertNull "RUBY_ROOT was not unset"     "$RUBY_ROOT"
-	assertNull "RUBY_ENGINE was not unset"   "$RUBY_ENGINE"
-	assertNull "RUBY_VERSION was not unset"  "$RUBY_VERSION"
-	assertNull "RUBYOPT was not unset"       "$RUBYOPT"
-	assertNull "GEM_HOME was not unset"      "$GEM_HOME"
-	assertNull "GEM_PATH was not unset"      "$GEM_PATH"
-
+	assertAllUnset
 	assertEquals "PATH was not sanitized"    "$test_path" "$PATH"
 }
 
 function test_chruby_reset_duplicate_path()
 {
 	export PATH="$PATH:$GEM_HOME/bin:$GEM_ROOT/bin:$RUBY_ROOT/bin"
-
 	chruby_reset
-
 	assertEquals "PATH was not sanitized"    "$test_path" "$PATH"
 }
 

--- a/test/chruby_reset_writable_gem_home_test.sh
+++ b/test/chruby_reset_writable_gem_home_test.sh
@@ -1,0 +1,30 @@
+. ./test/helper.sh
+
+function setUp()
+{
+	chruby_use "$test_ruby_root" >/dev/null
+
+	export PATH="$RUBY_ROOT/bin:$test_path"
+}
+
+function test_chruby_reset_hash_table()
+{
+	chruby_reset
+	assertClearPathTable
+}
+
+function test_chruby_reset_env_variables()
+{
+	chruby_reset
+	assertAllUnset
+	assertEquals "PATH was not sanitized"    "$test_path" "$PATH"
+}
+
+function test_chruby_reset_duplicate_path()
+{
+	export PATH="$PATH:$GEM_ROOT/bin:$RUBY_ROOT/bin"
+	chruby_reset
+	assertEquals "PATH was not sanitized"    "$test_path" "$PATH"
+}
+
+SHUNIT_PARENT=$0 . $SHUNIT2

--- a/test/chruby_use_writable_gem_home_test.sh
+++ b/test/chruby_use_writable_gem_home_test.sh
@@ -2,26 +2,17 @@
 
 function setUp()
 {
-	chmod u-w "$test_gem_root"
-	chruby_use "$test_ruby_root" >/dev/null
+	chruby_use $test_ruby_root >/dev/null
 }
 
 function tearDown()
 {
 	chruby_reset
-	chmod u+w "$test_gem_root"
 }
 
 function test_chruby_clears_hash_table()
 {
 	assertClearPathTable
-}
-
-function test_chruby_use_with_invalid_ruby_path()
-{
-	chruby_use "/path/to/fake/ruby" 2>/dev/null
-
-	assertEquals "did not return an error code" 1 $?
 }
 
 function test_chruby_use_env_variables()
@@ -30,9 +21,9 @@ function test_chruby_use_env_variables()
 	assertEquals "invalid RUBY_ENGINE"  "$test_ruby_engine" "$RUBY_ENGINE"
 	assertEquals "invalid RUBY_VERSION" "$test_ruby_version" "$RUBY_VERSION"
 	assertEquals "invalid GEM_ROOT"     "$test_ruby_root/lib/ruby/gems/$test_ruby_api" "$GEM_ROOT"
-	assertEquals "invalid GEM_HOME"     "$test_gem_home" "$GEM_HOME"
-	assertEquals "invalid GEM_PATH"     "$GEM_HOME:$GEM_ROOT" "$GEM_PATH"
-	assertEquals "invalid PATH"         "$test_gem_home/bin:$test_gem_root/bin:$test_ruby_root/bin:$__shunit_tmpDir:$test_path" "$PATH"
+	assertNull "GEM_HOME should not be set" "$GEM_HOME"
+	assertNull "GEM_PATH should not be set" "$GEM_PATH"
+	assertEquals "invalid PATH"         "$test_gem_root/bin:$test_ruby_root/bin:$__shunit_tmpDir:$test_path" "$PATH"
 
 	assertEquals "could not find ruby in $PATH" \
 		     "$test_ruby_root/bin/ruby" \

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -31,3 +31,22 @@ test_path="$PATH"
 setUp() { return; }
 tearDown() { return; }
 oneTimeTearDown() { return; }
+
+function assertClearPathTable() {
+	if [[ -n "$BASH_VERSION" ]]; then
+		assertEquals "did not clear the path table" \
+			     "hash: hash table empty" "$(hash)"
+	elif [[ -n "$ZSH_VERSION" ]]; then
+		assertEquals "did not clear the path table" \
+			     "" "$(hash)"
+	fi
+}
+
+function assertAllUnset() {
+	assertNull "RUBY_ROOT was not unset"     "$RUBY_ROOT"
+	assertNull "RUBY_ENGINE was not unset"   "$RUBY_ENGINE"
+	assertNull "RUBY_VERSION was not unset"  "$RUBY_VERSION"
+	assertNull "RUBYOPT was not unset"       "$RUBYOPT"
+	assertNull "GEM_HOME was not unset"      "$GEM_HOME"
+	assertNull "GEM_PATH was not unset"      "$GEM_PATH"
+}


### PR DESCRIPTION
See https://github.com/postmodern/chruby/issues/422#issuecomment-557379476
This is a cleaner alternative to https://github.com/postmodern/chruby/pull/423.

This solution feels both very nice and simple.
With this PR, `chruby` only sets and uses non-default configuration when needed, i.e., when the default gem directory is not writable.

If the default gem directory is writable, then it just use the default configuration and does not set GEM_HOME, which has multiple advantages as described in https://github.com/postmodern/chruby/issues/422.

The only drawback I know is it causes user-installed gems to be together with pre-installed gems. In the rare cases where one wants to remove all user-installed gems, one simple solution (and the safest in general) is to reinstall that Ruby.

@postmodern @havenwood Would it be fine to merge this?