### PR TITLE
Update instructions for running on OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Add the following to the `~/.bashrc` or `~/.zshrc` file:
 source /usr/local/share/chruby/chruby.sh
 ```
 
-*Note:* OSX does not automatically execute `~/.bashrc`, instead try adding to `/etc/bashrc`.
+*Note:* OSX does not automatically execute `~/.bashrc`, instead try adding to `~/.bash_profile`.
 
 ### System Wide
 


### PR DESCRIPTION
On OS X .bash_profile has precedence over .bashrc, so asking users to source chruby in .bash_profile means that they'll have fewer issues. As a side-note, modifying files in /etc/ makes it a lot harder to track down problems with the environment if they should occur.