### PR TITLE
Force `ls` to be a command

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -2,7 +2,7 @@ CHRUBY_VERSION="0.3.9"
 RUBIES=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+	[[ -d "$dir" && -n "$(command ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
 done
 unset dir
 


### PR DESCRIPTION
This forces `ls` to be a command. Without `command`, `ls` function or alias might affect the output. In my case I alias `ls` to [`exa`](https://the.exa.website), which doesn’t support `-A` (actually I have no idea why `-A` was used in the first place).