### PR TITLE
Added Zsh configuration instruction for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ source /usr/local/share/chruby/chruby.sh
 
 ``` bash
 
-source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh # Or run `brew info chruby` to find out installed directory
+source $HOMEBREW_PREFIX/opt/chruby/share/chruby/chruby.sh # Or run `brew info chruby` to find out installed directory
 ```
 
 *Note:* OSX does not automatically execute `~/.bashrc`, instead try adding to `/etc/bashrc`.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ Add the following to the `~/.bashrc` or `~/.zshrc` file:
 source /usr/local/share/chruby/chruby.sh
 ```
 
+#### Mac
+
+``` bash
+
+source $(brew --prefix)/opt/chruby/share/chruby/chruby.sh # Or run `brew info chruby` to find out installed directory
+```
+
 *Note:* OSX does not automatically execute `~/.bashrc`, instead try adding to `/etc/bashrc`.
 
 ### System Wide


### PR DESCRIPTION
Zsh configuration instruction for OSX wasn't accurate. Therefore, added
the related snippet

Note: 
I found actual installed directory by looking up source code (`opt_share` variable). So, I think it could help someone like me out there