### PR TITLE
Fix the instruction for macOS about Bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,22 @@ source /usr/local/share/chruby/chruby.sh
 source /usr/local/share/chruby/auto.sh
 ```
 
-*Note:* macOS does not automatically execute `~/.bashrc`, instead try adding to `/etc/bashrc`.
+> *Note:* macOS does not automatically source `~/.bashrc`. Bash users should
+> create the file `~/.bash_profile` with following content:
+>
+> ```bash
+> if [[ -f ~/.profile ]]; then
+>     source ~/.profile
+> fi
+>
+> if [[ $- == *i* ]] && [[ -f ~/.bashrc ]]; then
+>     source ~/.bashrc
+> fi
+> ```
+>
+> so that the terminal loads `~/.bashrc` and `~/.profile` (the POSIX one). If
+> `~/.bash_profile` exists, Bash users should append the above lines to
+> `~/.bash_profile` as needed.
 
 chruby will check the current and parent directories for a [.ruby-version]
 file. Other Ruby switchers also understand this file:


### PR DESCRIPTION
This is a follow-up on #437 and #438.

## background knowledge for Bash

If you run a Bash within a Bash, you are in a subshell. For example, if you execute `bash` after logging in, the shell process structure is like this:

```plain
bash (0, root)
 └── bash (1, subshell)
```

Then Bash No.0 would be the “interactive, login” shell, loading `~/.bash_profile` (falling back to `~/.profile` for compatibility) but _not_ `~/.bashrc`. In contrast, Bash No.1 would be an “interactive, _non-login_” shell, loading `~/.bashrc` but none of the profiles. Things are simpler in Linux workstation because Desktop Environments (GNOME, KDE Plasma, etc.) are typically the login shell, so all the Bash in terminal emulators (like GNOME Terminal) are non-login shells reading `~/.bashrc` as expected. macOS is the weird guy: every new tab in the terminal (both Terminal.app and iTerm2) is a login shell (looks like a new session). This macOS issue isn’t Bash-specific, but Zsh loads `~/.zshrc` regardless of the “login shell” bit, so Zsh users don’t even feel it.

The official solution, is to source `~/.bashrc` in `~/.bash_profile`, for a few reasons:

 1. This way, stuffs necessary for interactive use (like `chruby`) only need to specify once. Less typo, no need to synchronize rc-file and profile.
 2. This setup is portable; it works on both Linux and macOS.
 3. Unlike `~/.profile`, `~/.bash_profile` is Bash-specific (hence the name), so we don’t need to test whether in Bash. As a result, this won’t affect other POSIX shells (or shells that may or may not read `~/.profile`).
 4. Users can put some POSIX stuffs in `~/.profile`, shared by various POSIX shells, if desired.

## other notes

  - Double brackets are used instead of single bracket (i.e. `test`), because `~/.bash_profile` should only be read by Bash, not any random POSIX shell.
  - Using `source` instead of `.` for the same reason.
  - I’m (ab)using blockquote syntax to indicate that they belong to the same note (i.e. “group” them together); alternatively they could all be italic, but that looks distracting. (“Blockquote” is the way we implement “call-outs in Markdown” in Google.) It’s subjective; feel free to disagree.
  - I’m not sure whether I assumed too little knowledge from the `chruby` users. This note might sound too verbose; please adjust it to your taste.
  - About this problem, I didn’t find good and concise description about it elsewhere. I read all the answers in [*Why doesn't Mac OS X source ~/.bashrc? [duplicate]* - Ask Different](https://apple.stackexchange.com/questions/119711/why-doesnt-mac-os-x-source-bashrc) and [*Why doesn't .bashrc run automatically?* - Ask Different](https://apple.stackexchange.com/questions/12993/why-doesnt-bashrc-run-automatically); the answers focus on “how to fix” but not “why it broke”. I’m seriously considering, maybe just add my answer below focusing on the Why part.