### PR TITLE
[WIP] remove call to external ls when loading chruby

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -2,9 +2,10 @@ CHRUBY_VERSION="0.3.9"
 RUBIES=()
 
 for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(command ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+  [[ -d "$dir" ]] && dir_contents=("$dir"/*) && \
+    [[ ${#dir_contents[@]} -gt 0 ]] && RUBIES+=(${dir_contents[@]})
 done
-unset dir
+unset dir dir_contents
 
 function chruby_reset()
 {


### PR DESCRIPTION
### before

```
/Users/kbrock/dotfiles/bashrc.d/chruby.sh

real	0m0.004s
user	0m0.001s
sys	0m0.001s
```

### after

```
/Users/kbrock/dotfiles/bashrc.d/chruby.sh

real	0m0.000s
user	0m0.000s
sys	0m0.000s
```

### why?

I was trying to figure out ways to make nvm.sh load faster on my system.
chruby loads so much faster, and when I looked to see why, I was distracted by the call to `ls -A "$dir"`. It was using a builtin to list the files in the directory, but an external command to detect if there were files in the directory.

So yea, I converted the already quick method to made it even faster.

- I tested with my files in `~/.rubies`, and a non-existent `/opt/rubies`.
- I did not test this with a directory with a space in the name, but didn't see how that could be possible other than having a `PREFIX` with a space in the name.
- I did not test with rubies that start with a period, but it looked like the original script did not handle that case either. And it didn't seem valid.


This is yak shaving, and you probably can think up a better implementation. But it seems to work in `zsh` and `bash`.

If you prefer not to introduce change (because change always introduces risk), then that is cool. Just close.
I just saw this change and wanted to share.

As you will note, `nvm` is noticeably slower and the reason for my original tangent:

```
/Users/kbrock/dotfiles/bashrc.d/node.bash

real	0m0.177s
user	0m0.033s
sys	0m0.089s
```

Thanks again for such a great tool. And it already performs heads and shoulders better than other tools out there. (ruby or other)

refs:
- https://github.com/kbrock/dotfiles/blob/master/bashrc.d/chruby.sh
- https://github.com/kbrock/dotfiles/blob/master/bashrc.d/node.bash (since changed to speed this up)