### PR TITLE
move ruby discovery code into a function

### DIFF
--- a/share/chruby/chruby.sh
+++ b/share/chruby/chruby.sh
@@ -1,10 +1,13 @@
 CHRUBY_VERSION="0.3.9"
-RUBIES=()
 
-for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
-	[[ -d "$dir" && -n "$(command ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
-done
-unset dir
+function chruby_discover()
+{
+	RUBIES=()
+	local dir
+	for dir in "$PREFIX/opt/rubies" "$HOME/.rubies"; do
+		[[ -d "$dir" && -n "$(command ls -A "$dir")" ]] && RUBIES+=("$dir"/*)
+	done
+}
 
 function chruby_reset()
 {
@@ -102,3 +105,5 @@ function chruby()
 			;;
 	esac
 }
+
+chruby_discover


### PR DESCRIPTION
When you install a new ruby in a different terminal shell, chruby does not pick up on the new ruby version.

The solution is to to source chruby.sh again.
Introducing chruby_discover which will allow any shell to pick up on the new ruby versions

---

Yes, I was trying to "optimize" this functionality in #492 - but this PR is not an optimization play.

I have had this function defined in my bashrc for a while and thought others may want it as well.