### PR TITLE
Fix RPM build on COPR

### DIFF
--- a/rpm/chruby.spec
+++ b/rpm/chruby.spec
@@ -14,6 +14,7 @@ License: MIT
 URL: https://github.com/postmodern/chruby#readme
 AutoReqProv: no
 BuildArch: noarch
+BuildRequires: make
 
 %description
 Changes the current Ruby.

--- a/rpm/sources
+++ b/rpm/sources
@@ -1,1 +1,0 @@
-20122a98094f0da0eb03b08f8bc331dc	chruby-0.3.9.tar.gz


### PR DESCRIPTION
I wanted to build chruby in my Fedora COPR at https://copr.fedorainfracloud.org/coprs/gschlager/ruby/ and noticed that it didn't work anymore. I had to make changes to `rpm/chruby.spec` and delete `rpm/sources` to make the build work.

This is related to https://github.com/postmodern/ruby-install/pull/492